### PR TITLE
Update Stan example to compile, return -inf on failure

### DIFF
--- a/examples/load_stan.hpp
+++ b/examples/load_stan.hpp
@@ -3,6 +3,8 @@
 
 #include <bridgestan.h>
 
+#include <cmath>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -130,7 +132,11 @@ class DynamicStanModel {
       if (err) {
         std::string error_string(err);
         free_error_msg_(err);
-        throw std::runtime_error(error_string);
+        std::cerr << "Error in logp_grad: " << error_string << std::endl;
+
+        logp = -INFINITY;
+        grad.setZero();
+        return;
       }
       throw std::runtime_error("Failed to compute log density and gradient");
     }
@@ -146,7 +152,9 @@ class DynamicStanModel {
       if (err) {
         std::string error_string(err);
         free_error_msg_(err);
-        throw std::runtime_error(error_string);
+        std::cerr << "Error in constrain_draw: " << error_string << std::endl;
+        out.array() = NAN;
+        return;
       }
       throw std::runtime_error("Failed to constrain draw");
     }


### PR DESCRIPTION
Copies over some changes from test.cpp that got missed, and changes the test code to work around the lack of exception catching in the algorithm (#4).

This now means it can be used on relatively 'real' models like the SIR ode model. Before these would crash during initialization due to the errors Stan was throwing