### PR TITLE
access tuning parameters

### DIFF
--- a/examples/test.cpp
+++ b/examples/test.cpp
@@ -117,7 +117,7 @@ static void test_walnuts(const F& target_logp_grad, VectorS theta_init,
             << ";  max_error = " << max_error << std::endl;
   global_start_timer();
   nuts::Random<double, RNG> rand(rng);
-  nuts::WalnutsSampler sample(rand, target_logp_grad, theta_init, inv_mass,
+  nuts::WalnutsSampler<F, S, RNG> sample(rand, target_logp_grad, theta_init, inv_mass,
                               macro_step_size, max_nuts_depth, max_error);
   MatrixS draws(D, N);
   for (Integer n = 0; n < N; ++n) {
@@ -133,9 +133,9 @@ static void test_adaptive_walnuts(const F& target_logp_grad,
                                   Integer D, Integer N, Integer max_nuts_depth,
                                   S max_error) {
   Eigen::VectorXd mass_init = Eigen::VectorXd::Ones(D);
-  double init_count = 10.0;
-  double mass_iteration_offset = 4.0;
-  double additive_smoothing = 0.05;
+  double init_count = 2;
+  double mass_iteration_offset = 2;
+  double additive_smoothing = 0.001;
   nuts::MassAdaptConfig mass_cfg(mass_init, init_count, mass_iteration_offset,
                                  additive_smoothing);
   double step_size_init = 1.0;
@@ -156,9 +156,31 @@ static void test_adaptive_walnuts(const F& target_logp_grad,
   global_start_timer();
   nuts::AdaptiveWalnuts walnuts(rng, target_logp_grad, theta_init, mass_cfg,
                                 step_cfg, walnuts_cfg);
+
+  std::ofstream out("adapt_mass.csv");
+  std::ofstream out_step("adapt_step.csv");
+  std::ofstream out_grads("adapt_grads.csv");
   for (Integer n = 0; n < N; ++n) {
     walnuts();
+    auto mass_mat = walnuts.inv_mass();
+    out << mass_mat[0]
+	<< ", " << mass_mat[2]
+	<< ", " << mass_mat[9]
+	<< ", " << mass_mat[29]
+	<< ", " << mass_mat[49]
+	<< ", " << mass_mat[99]
+	<< ", " << mass_mat[149]
+	<< ", " << mass_mat[199]
+	<< std::endl;
+    out_step << walnuts.step_size() 
+	     << std::endl;
+    out_grads << walnuts.logp_grad_calls()
+	      << std::endl;
   }
+  out.close();
+  out_step.close();
+  out_grads.close();
+  
   auto sampler = walnuts.sampler();
   MatrixS draws(D, N);
   for (Integer n = 0; n < N; ++n) {

--- a/extras/.gitignore
+++ b/extras/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!readme.md

--- a/extras/readme.md
+++ b/extras/readme.md
@@ -1,1 +1,0 @@
-This folder is for additional utilities for developers. If the top level cmake sees a `CMakeLists.txt` file in this folder it will include this subdirectory.

--- a/include/walnuts/adaptive_walnuts.hpp
+++ b/include/walnuts/adaptive_walnuts.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <fstream>
 #include <utility>
 
 #include "dual_average.hpp"
@@ -504,10 +505,39 @@ class AdaptiveWalnuts {
    * @return The WALNUTS sampler with current tuning parameter estimates.
    */
   WalnutsSampler<F, S, RNG> sampler() {
-    return WalnutsSampler<F, S, RNG>(
-        rand_, logp_grad_.logp_grad_, theta_, mass_estimator_.inv_mass_estimate(),
-        step_adapt_handler_.step_size(), walnuts_cfg_.max_nuts_depth_,
-        walnuts_cfg_.log_max_error_);
+    return WalnutsSampler<F, S, RNG>(rand_, logp_grad_, theta_,
+				     mass_estimator_.inv_mass_estimate(),
+				     step_adapt_handler_.step_size(),
+				     walnuts_cfg_.max_nuts_depth_,
+				     walnuts_cfg_.log_max_error_);
+  }
+
+  /**
+   * @brief Return the number of log density/gradient calls so far.
+   *
+   * @return The number of log density/gradient calls.
+   */
+  Integer logp_grad_calls() const noexcept {
+    return logp_grad_.logp_grad_calls();
+  }
+
+  /**
+   * @brief Return the diagonal of the current diagonal inverse mass
+   * matrix.
+   *
+   * @return The diagonal of the inverse mass matrix.
+   */
+  Vec<S> inv_mass() const {
+    return mass_estimator_.inv_mass_estimate();
+  }
+
+  /**
+   * @brief Return the current step size.
+   *
+   * @return The current step size.
+   */
+  S step_size() const {
+    return step_adapt_handler_.step_size();
   }
 
  private:

--- a/include/walnuts/nuts.hpp
+++ b/include/walnuts/nuts.hpp
@@ -107,7 +107,7 @@ class Span {
  * @pre theta.size() == inv_mass.size()
  */
 template <typename S, typename F>
-void leapfrog(const F &logp_grad, const Vec<S> &inv_mass, S step,
+void leapfrog(F &logp_grad, const Vec<S> &inv_mass, S step,
               const Vec<S> &theta, const Vec<S> &rho, const Vec<S> &grad,
               Vec<S> &theta_next, Vec<S> &rho_next, Vec<S> &grad_next,
               S &logp_next) {
@@ -167,7 +167,7 @@ Span<S> combine(Random<S, RNG> &rand, Span<S> &&span_old, Span<S> &&span_new) {
  * @return The single-state span that follows the specified span.
  */
 template <Direction D, typename S, class F>
-Span<S> build_leaf(const F &logp_grad, const Span<S> &span,
+Span<S> build_leaf(F &logp_grad, const Span<S> &span,
                    const Vec<S> &inv_mass, S step) {
   Vec<S> theta_next;
   Vec<S> rho_next;
@@ -206,7 +206,7 @@ Span<S> build_leaf(const F &logp_grad, const Span<S> &span,
  * @return The new span of `std::nullopt` if there was a sub-u-turn.
  */
 template <Direction D, typename S, class F, class RNG>
-std::optional<Span<S>> build_span(Random<S, RNG> &rand, const F &logp_grad,
+std::optional<Span<S>> build_span(Random<S, RNG> &rand, F &logp_grad,
                                   const Vec<S> &inv_mass, S step, Integer depth,
                                   const Span<S> &last_span) {
   if (depth == 0) {
@@ -247,7 +247,7 @@ std::optional<Span<S>> build_span(Random<S, RNG> &rand, const F &logp_grad,
  * @return The next state in the NUTS Markov chain.
  */
 template <typename S, class F, class RNG>
-Vec<S> transition(Random<S, RNG> &rand, const F &logp_grad,
+Vec<S> transition(Random<S, RNG> &rand, F &logp_grad,
                   const Vec<S> &inv_mass, const Vec<S> &chol_mass, S step,
                   Integer max_depth, Vec<S> &&theta) {
   Vec<S> rho = rand.standard_normal(theta.size()).cwiseProduct(chol_mass);
@@ -353,6 +353,15 @@ class Nuts {
     theta_ = transition(rand_, logp_grad_, inv_mass_, cholesky_mass_,
                         step_size_, max_nuts_depth_, std::move(theta_));
     return theta_;
+  }
+
+  /**
+   * @brief Return the number of log density/gradient calls so far.
+   *
+   * @return The number of log density/gradient calls.
+   */
+  Integer logp_grad_calls() const noexcept {
+    return logp_grad_.logp_grad_calls();
   }
 
  private:

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -252,7 +252,7 @@ class NoExceptLogpGrad {
    *
    * @param logp_grad The base log density and gradient function.
    */
-  NoExceptLogpGrad(F& logp_grad): logp_grad_(logp_grad) { }
+  NoExceptLogpGrad(const F& logp_grad): logp_grad_(logp_grad), calls_(0) { }
 
   /**
    * @brief Given the specified position, set the log density and
@@ -262,8 +262,8 @@ class NoExceptLogpGrad {
    * @param[out] logp The log density to set.
    * @param[out] grad The gradient to set.
    */
-  inline void operator()(const Vec<S>& x, S& logp, Vec<S>& grad)
-    const noexcept {
+  inline void operator()(const Vec<S>& x, S& logp, Vec<S>& grad) noexcept {
+    ++calls_;
     try {
       logp_grad_(x, logp, grad);
     } catch (...) {
@@ -273,7 +273,17 @@ class NoExceptLogpGrad {
     }
   }    
 
-  F& logp_grad_;
+  /**
+   * @brief Return the number of log density/gradient calls.
+   *
+   * @return The number of calls.
+   */
+  Integer logp_grad_calls() const noexcept {
+    return calls_;
+  }
+  
+  const F& logp_grad_;
+  Integer calls_;
 };
   
 }  // namespace nuts


### PR DESCRIPTION
I added methods on all the samplers to allow them to access the current mass matrix and step size and number of gradients called.  

I have other code for plotting all the output from the C++ tests, but that's not clean enough to commit yet.  I did instrument the tests to dump out the adapted mass matrix and step sizes.