### PR TITLE
rename test_nuts, tweak tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run examples
         run: |
           cd build/
-          ./test_nuts
+          ./examples
         shell: bash
 
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,12 +128,12 @@ endif()
 add_library(nuts::nuts ALIAS walnuts)
 
 ##########################
-##       Example        ##
+##       Examples       ##
 ##########################
 if (WALNUTS_BUILD_EXAMPLES)
-  add_executable(test_nuts ${CMAKE_CURRENT_SOURCE_DIR}/examples/test.cpp)
-  target_link_libraries(test_nuts PRIVATE nuts::nuts)
-  target_compile_options(test_nuts PRIVATE -Wall)
+  add_executable(examples ${CMAKE_CURRENT_SOURCE_DIR}/examples/examples.cpp)
+  target_link_libraries(examples PRIVATE nuts::nuts)
+  target_compile_options(examples PRIVATE -O3 -Wall)
 endif()
 
 ##########################

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ licensed](https://opensource.org/license/bsd-3-clause))
 ## Using WALNUTS in a C++ project
 
 This library is header only and only requires Eigen (also header only)
-to run (additional dependencies are required for testing and documtnation). 
+to run (additional dependencies are required for testing and documtnation).
 If your project uses CMake, you can depend on our
 `walnuts` library target. If not, any method of adding the `include/`
 folder of this repository to your build system's include paths should suffice
@@ -97,8 +97,8 @@ command. This will build all available executable targets by default.
 For example, to build and run the example:
 
 ```bash
-cmake --build . --target test_nuts
-./test_nuts
+cmake --build . --target examples
+./examples
 ```
 
 

--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -86,10 +86,10 @@ static void summarize(const MatrixS& draws) {
 }
 
 template <typename F, typename RNG>
-static void test_nuts(const F& target_logp_grad, const VectorS& theta_init,
-                      RNG& rng, Integer D, Integer N, S step_size,
-                      Integer max_depth, const VectorS& inv_mass) {
-  std::cout << "\nTEST NUTS"
+static void run_nuts(const F& target_logp_grad, const VectorS& theta_init,
+                     RNG& rng, Integer D, Integer N, S step_size,
+                     Integer max_depth, const VectorS& inv_mass) {
+  std::cout << "\nRUN NUTS"
             << ";  D = " << D << ";  N = " << N
             << ";  step_size = " << step_size << ";  max_depth = " << max_depth
             << std::endl;
@@ -106,11 +106,10 @@ static void test_nuts(const F& target_logp_grad, const VectorS& theta_init,
 }
 
 template <typename F, typename RNG>
-static void test_walnuts(const F& target_logp_grad, VectorS theta_init,
-                         RNG& rng, Integer D, Integer N, S macro_step_size,
-                         Integer max_nuts_depth, S max_error,
-                         VectorS inv_mass) {
-  std::cout << "\nTEST WALNUTS"
+static void run_walnuts(const F& target_logp_grad, VectorS theta_init, RNG& rng,
+                        Integer D, Integer N, S macro_step_size,
+                        Integer max_nuts_depth, S max_error, VectorS inv_mass) {
+  std::cout << "\nRUN WALNUTS"
             << ";  D = " << D << ";  N = " << N
             << ";  macro_step_size = " << macro_step_size
             << ";  max_nuts_depth = " << max_nuts_depth
@@ -128,19 +127,19 @@ static void test_walnuts(const F& target_logp_grad, VectorS theta_init,
 }
 
 template <typename F, typename RNG>
-static void test_adaptive_walnuts(const F& target_logp_grad,
-                                  const VectorS& theta_init, RNG& rng,
-                                  Integer D, Integer N, Integer max_nuts_depth,
-                                  S max_error) {
+static void run_adaptive_walnuts(const F& target_logp_grad,
+                                 const VectorS& theta_init, RNG& rng, Integer D,
+                                 Integer N, Integer max_nuts_depth,
+                                 S max_error) {
   Eigen::VectorXd mass_init = Eigen::VectorXd::Ones(D);
-  double init_count = 10.0;
-  double mass_iteration_offset = 4.0;
-  double additive_smoothing = 0.05;
+  double init_count = 1.1;
+  double mass_iteration_offset = 1.1;
+  double additive_smoothing = 0.1;
   nuts::MassAdaptConfig mass_cfg(mass_init, init_count, mass_iteration_offset,
                                  additive_smoothing);
-  double step_size_init = 1.0;
-  double accept_rate_target = 0.8;
-  double step_iteration_offset = 4.0;
+  double step_size_init = 0.5;
+  double accept_rate_target = 2.0 / 3.0;
+  double step_iteration_offset = 2.0;
   double learning_rate = 0.95;
   double decay_rate = 0.05;
   nuts::StepAdaptConfig step_cfg(step_size_init, accept_rate_target,
@@ -148,7 +147,7 @@ static void test_adaptive_walnuts(const F& target_logp_grad,
                                  decay_rate);
   Integer max_step_depth = 8;
   nuts::WalnutsConfig walnuts_cfg(max_error, max_nuts_depth, max_step_depth);
-  std::cout << "\nTEST ADAPTIVE WALNUTS"
+  std::cout << "\nRUN ADAPTIVE WALNUTS"
             << ";  D = " << D << ";  N = " << N
             << "; step_size_init = " << step_size_init
             << "; max_nuts_depth = " << max_nuts_depth
@@ -177,30 +176,32 @@ int main() {
   unsigned int seed = 428763;
   Integer D = 200;
   Integer N = 1000;
-  S step_size = 0.465;
+  S step_size = 0.5;
   Integer max_depth = 10;
   S max_error = 1.0;  // 61% Metropolis
   VectorS inv_mass = VectorS::Ones(D);
   std::mt19937 rng(seed);
 
-  // std::normal_distribution<S> std_normal(0, 1);
-  // VectorS theta_init(D);
-  // for (Integer i = 0; i < D; ++i) {
-  //   theta_init(i) = std_normal(rng);
-  // }
-  VectorS theta_init = VectorS::Zero(D);
+  std::normal_distribution<S> std_normal(0, 1);
+  VectorS theta_init(D);
+  for (Integer i = 0; i < D; ++i) {
+    theta_init(i) = std_normal(rng);
+  }
 
-  // auto target_logp_grad = std_normal_logp_grad;
+  // alternatively, uncomment following to init at bottleneck
+  // VectorS theta_init = VectorS::Zero(D);
+
   auto target_logp_grad = ill_cond_normal_logp_grad;
+  // auto target_logp_grad = std_normal_logp_grad;
 
-  test_nuts(target_logp_grad, theta_init, rng, D, N, step_size, max_depth,
-            inv_mass);
+  run_nuts(target_logp_grad, theta_init, rng, D, N, step_size, max_depth,
+           inv_mass);
 
-  test_walnuts(target_logp_grad, theta_init, rng, D, N, step_size, max_depth,
-               max_error, inv_mass);
+  run_walnuts(target_logp_grad, theta_init, rng, D, N, step_size, max_depth,
+              max_error, inv_mass);
 
-  test_adaptive_walnuts(target_logp_grad, theta_init, rng, D, N, max_depth,
-                        max_error);
+  run_adaptive_walnuts(target_logp_grad, theta_init, rng, D, N, max_depth,
+                       max_error);
 
   return 0;
 }


### PR DESCRIPTION
* renamed `test.cpp` to `examples.cpp` and renamed matching build target `test_nuts` to `examples`.  
* tweaked tuning parameters for adaptation (still a WIP)
