### PR TITLE
adapt accessors, const logp_grad

### DIFF
--- a/include/walnuts/nuts.hpp
+++ b/include/walnuts/nuts.hpp
@@ -90,7 +90,7 @@ class Span {
  *
  * @tparam S The type of scalars.
  * @tparam F The type of the target log density/gradient function.
- * @param[in,out] logp_grad The target log density/gradient function.
+ * @param[in] logp_grad The target log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix
  * (finite positive components).
  * @param[in] step The step size.
@@ -159,7 +159,7 @@ Span<S> combine(Random<S, RNG>& rand, Span<S>&& span_old, Span<S>&& span_new) {
  * @tparam D The temporal direction in which to extend the last span.
  * @tparam S The type of scalars.
  * @tparam F The type of the target log density/gradient function.
- * @param[in,out] logp_grad The target log density/gradient function.
+ * @param[in] logp_grad The target log density/gradient function.
  * @param[in] span The span to extend.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix
  * (positive finite components).
@@ -197,7 +197,7 @@ Span<S> build_leaf(const F& logp_grad, const Span<S>& span,
  * @tparam F The type of the target log density/gradient function.
  * @tparam RNG The type of the base random number generator.
  * @param[in,out] rand The compound random number generator.
- * @param[in,out] logp_grad The target log density/gradient function.
+ * @param[in] logp_grad The target log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix (finite
  * positive components).
  * @param[in] step The step size (finite positive floating point).
@@ -237,7 +237,7 @@ std::optional<Span<S>> build_span(Random<S, RNG>& rand, const F& logp_grad,
  * @tparam F The type of the log density/gradient function.
  * @tparam RNG The type of the base random number generator.
  * @param[in,out] rand The compound random number generator.
- * @param[in,out] logp_grad The target log density/gradient function.
+ * @param[in] logp_grad The target log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] chol_mass The diagonal of the diagonal Cholesky factor of the mass
  * matrix.
@@ -322,7 +322,7 @@ class Nuts {
    * log density, initialization, and tuning parameters.
    *
    * @param[in,out] rand The compound random number generator for MCMC.
-   * @param[in,out] logp_grad The target log density/gradient function.
+   * @param[in] logp_grad The target log density/gradient function.
    * @param[in] theta_init The initial position.
    * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix
    * (finite positive components).
@@ -332,7 +332,7 @@ class Nuts {
    * @pre step_size > 0
    * @pre theta_init.size() == inv_mass.size()
    */
-  Nuts(Random<S, RNG>& rand, F& logp_grad, const Vec<S>& theta_init,
+  Nuts(Random<S, RNG>& rand, const F& logp_grad, const Vec<S>& theta_init,
        const Vec<S>& inv_mass, S step_size, Integer max_nuts_depth)
       : rand_(rand),
         logp_grad_(logp_grad),
@@ -360,7 +360,7 @@ class Nuts {
   Random<S, RNG> rand_;
 
   /** The target log density/gradient function. */
-  NoExceptLogpGrad<F, S> logp_grad_;
+  const NoExceptLogpGrad<F, S> logp_grad_;
 
   /** The current state. */
   Vec<S> theta_;

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -250,9 +250,12 @@ class NoExceptLogpGrad {
    * @brief Construct a log density and gradient function from a base
    * log density and gradient function.
    *
+   * The log density and gradient function will be stored as a
+   * constant reference.
+   *
    * @param logp_grad The base log density and gradient function.
    */
-  NoExceptLogpGrad(F& logp_grad) : logp_grad_(logp_grad) {}
+  NoExceptLogpGrad(const F& logp_grad) : logp_grad_(logp_grad) {}
 
   /**
    * @brief Given the specified position, set the log density and
@@ -273,7 +276,7 @@ class NoExceptLogpGrad {
     }
   }
 
-  F& logp_grad_;
+  const F& logp_grad_;
 };
 
 }  // namespace nuts

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -115,7 +115,7 @@ class SpanW {
  *
  * @tparam S The type of scalars.
  * @tparam F The type of the log density/gradient function.
- * @param[in,out] logp_grad The log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The micro step size.
  * @param[in] num_steps The number of micro steps to take.
@@ -126,7 +126,7 @@ class SpanW {
  * @param[in,out] grad_next Input initial gradient, set to final gradient.
  */
 template <typename S, typename F>
-bool within_tolerance(F& logp_grad, const Vec<S>& inv_mass, S step,
+bool within_tolerance(const F& logp_grad, const Vec<S>& inv_mass, S step,
                       Integer num_steps, S max_error, S logp_next,
                       Vec<S>& theta_next, Vec<S>& rho_next, Vec<S>& grad_next) {
   S half_step = 0.5 * step;
@@ -148,7 +148,7 @@ bool within_tolerance(F& logp_grad, const Vec<S>& inv_mass, S step,
  *
  * @tparam S Type of scalars.
  * @tparam F Type of log density/gradient function.
- * @param[in,out] logp_grad The log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The micro step size.
  * @param[in] num_steps The number of micro steps to take.
@@ -160,9 +160,9 @@ bool within_tolerance(F& logp_grad, const Vec<S>& inv_mass, S step,
  * @return `true` if the path ending in the specified state is reversible.
  */
 template <typename S, typename F>
-bool reversible(F& logp_grad, const Vec<S>& inv_mass, S step, Integer num_steps,
-                S max_error, S logp_next, const Vec<S>& theta,
-                const Vec<S>& rho, const Vec<S>& grad) {
+bool reversible(const F& logp_grad, const Vec<S>& inv_mass, S step,
+                Integer num_steps, S max_error, S logp_next,
+                const Vec<S>& theta, const Vec<S>& rho, const Vec<S>& grad) {
   if (num_steps == 1) {
     return true;
   }
@@ -192,7 +192,7 @@ bool reversible(F& logp_grad, const Vec<S>& inv_mass, S step, Integer num_steps,
  * @tparam S The type of scalars.
  * @tparam F The type of the log density/gradient function.
  * @tparam A The type of the adaptation handler.
- * @param[in,out] logp_grad The target log density/gradient function.
+ * @param[in] logp_grad The target log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The macro step size.
  * @param[in] max_error The maximum Hamiltonian diference allowed in the macro
@@ -207,7 +207,7 @@ bool reversible(F& logp_grad, const Vec<S>& inv_mass, S step, Integer num_steps,
  * @return `true` if the Hamiltonian is conserved reversibly.
  */
 template <Direction D, typename S, typename F, class A>
-bool macro_step(F& logp_grad, const Vec<S>& inv_mass, S step, S max_error,
+bool macro_step(const F& logp_grad, const Vec<S>& inv_mass, S step, S max_error,
                 const SpanW<S>& span, Vec<S>& theta_next, Vec<S>& rho_next,
                 Vec<S>& grad_next, S& logp_next, A& adapt_handler) {
   constexpr bool is_forward = (D == Direction::Forward);
@@ -307,7 +307,7 @@ SpanW<S> combine(Random<S, RNG>& rng, SpanW<S>&& span_old,
  * @tparam S The type of scalars.
  * @tparam F The type of the log density/gradient function.
  * @tparam A The type of the adaptation handler.
- * @param[in,out] logp_grad The log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
  * @param[in] span The span to extend.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The macro step size.
@@ -343,7 +343,7 @@ std::optional<SpanW<S>> build_leaf(const F& logp_grad, const SpanW<S>& span,
  * @tparam RNG The type of the base random number generator.
  * @tparam A The type of the step-size adaptation callback function.
  * @param[in,out] rng The random number generator.
- * @param[in,out] logp_grad The log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The macro step size.
  * @param[in] depth The maximum NUTS depth.
@@ -388,7 +388,7 @@ std::optional<SpanW<S>> build_span(Random<S, RNG>& rng, const F& logp_grad,
  * @tparam RNG The type of the base random number generator.
  * @tparam A The type of the step-size adaptation callback function.
  * @param[in,out] rand The random number generator.
- * @param[in,out] logp_grad The log density/gradient function.
+ * @param[in] logp_grad The log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] chol_mass The diagonal of the diagonal Cholesky factor of the mass
  * matrix.
@@ -506,7 +506,7 @@ class WalnutsSampler {
    * @param log_max_error The log of the maximum error in joint densities
    * allowed in Hamiltonian trajectories.
    */
-  WalnutsSampler(Random<S, RNG>& rand, F& logp_grad, const Vec<S>& theta,
+  WalnutsSampler(Random<S, RNG>& rand, const F& logp_grad, const Vec<S>& theta,
                  const Vec<S>& inv_mass, S macro_step_size,
                  Integer max_nuts_depth, S log_max_error)
       : rand_(rand),
@@ -558,7 +558,7 @@ class WalnutsSampler {
   Random<S, RNG> rand_;
 
   /** The target log density/gradient function. */
-  NoExceptLogpGrad<F, S> logp_grad_;
+  const NoExceptLogpGrad<F, S> logp_grad_;
 
   /** The current position. */
   Vec<S> theta_;


### PR DESCRIPTION
1. Add accessors for step size and inverse mass matrix to adaptive WALNUTS (lines 513--527 of `adaptive_walnuts.hpp`)

2. Mark all uses of `logp_grad` as `const`.

