### PR TITLE
Named factory methods for Spans, simplify testing with aggregate initialization

### DIFF
--- a/tests/combine_span_test.cpp
+++ b/tests/combine_span_test.cpp
@@ -15,27 +15,18 @@ namespace span_test {
  * to this function will return spans with different forward/backward/selected
  * points.
  */
-nuts::SpanW<double> dummy_span(double logp) {
-  Eigen::VectorXd theta = Eigen::VectorXd::Random(2);
-  Eigen::VectorXd rho = Eigen::VectorXd::Random(2);
-  Eigen::VectorXd grad = Eigen::VectorXd::Random(2);
-
-  nuts::SpanW<double> span(std::move(theta), std::move(rho), std::move(grad),
-                           logp);
-
-  span.logp_bk_ = -logp;
-
-  span.theta_bk_ = Eigen::VectorXd::Random(2);
-  span.rho_bk_ = Eigen::VectorXd::Random(2);
-  span.grad_theta_bk_ = Eigen::VectorXd::Random(2);
-
-  span.logp_fw_ = logp + 10;
-
-  span.theta_fw_ = Eigen::VectorXd::Random(2);
-  span.rho_fw_ = Eigen::VectorXd::Random(2);
-  span.grad_theta_fw_ = Eigen::VectorXd::Random(2);
-
-  return span;
+nuts::SpanW<double> dummy_span(double logp, int size = 2) {
+  return nuts::SpanW<double>{Eigen::VectorXd::Random(size),
+                             Eigen::VectorXd::Random(size),
+                             Eigen::VectorXd::Random(size),
+                             -logp,
+                             Eigen::VectorXd::Random(size),
+                             Eigen::VectorXd::Random(size),
+                             Eigen::VectorXd::Random(size),
+                             logp + 10,
+                             Eigen::VectorXd::Random(size),
+                             Eigen::VectorXd::Random(size),
+                             logp};
 }
 
 /** Mocked nuts::Random that returns a set value deterministically */

--- a/tests/util_test.cpp
+++ b/tests/util_test.cpp
@@ -18,7 +18,6 @@ static Vec vec(S x1, S x2) {
 }
 
 TEST(Util, Walnuts) {
-  EXPECT_EQ(2 + 2, 4);
   Vec thetabk1 = vec(-3, 0);
   Vec thetafw1 = vec(-1, 0);
   Vec thetabk2 = vec(1, 0);
@@ -50,19 +49,11 @@ TEST(Util, Walnuts) {
 
   Vec inv_mass = vec(1, 1);
 
-  nuts::SpanW<S> span1bk(std::move(thetabk1), std::move(rhobk1),
-                         std::move(gradbk1), logpbk1);
-  nuts::SpanW<S> span1fw(std::move(thetafw1), std::move(rhofw1),
-                         std::move(gradfw1), logpfw1);
-  nuts::SpanW<S> span2bk(std::move(thetabk2), std::move(rhobk2),
-                         std::move(gradbk2), logpbk2);
-  nuts::SpanW<S> span2fw(std::move(thetafw2), std::move(rhofw2),
-                         std::move(gradfw2), logpfw2);
+  nuts::SpanW<S> span1{thetabk1, rhobk1,  gradbk1, logpbk1, thetafw1, rhofw1,
+                       gradfw1,  logpfw1, theta1,  grad1,   logp1};
 
-  nuts::SpanW<S> span1(std::move(span1bk), std::move(span1fw),
-                       std::move(theta1), std::move(grad1), logp1);
-  nuts::SpanW<S> span2(std::move(span2bk), std::move(span2fw),
-                       std::move(theta2), std::move(grad2), logp2);
+  nuts::SpanW<S> span2{thetabk2, rhobk2,  gradbk2, logpbk2, thetafw2, rhofw2,
+                       gradfw2,  logpfw2, theta2,  grad2,   logp2};
 
   EXPECT_TRUE((nuts::uturn<nuts::Direction::Forward, S, nuts::SpanW<S>>(
       span1, span2, inv_mass)));
@@ -107,19 +98,11 @@ TEST(Util, WalnutsRegression) {
 
   Vec inv_mass = vec(1, 1);
 
-  nuts::SpanW<S> span1bk(std::move(thetabk1), std::move(rhobk1),
-                         std::move(gradbk1), logpbk1);
-  nuts::SpanW<S> span1fw(std::move(thetafw1), std::move(rhofw1),
-                         std::move(gradfw1), logpfw1);
-  nuts::SpanW<S> span2bk(std::move(thetabk2), std::move(rhobk2),
-                         std::move(gradbk2), logpbk2);
-  nuts::SpanW<S> span2fw(std::move(thetafw2), std::move(rhofw2),
-                         std::move(gradfw2), logpfw2);
+  nuts::SpanW<S> span1{thetabk1, rhobk1,  gradbk1, logpbk1, thetafw1, rhofw1,
+                       gradfw1,  logpfw1, theta1,  grad1,   logp1};
 
-  nuts::SpanW<S> span1(std::move(span1bk), std::move(span1fw),
-                       std::move(theta1), std::move(grad1), logp1);
-  nuts::SpanW<S> span2(std::move(span2bk), std::move(span2fw),
-                       std::move(theta2), std::move(grad2), logp2);
+  nuts::SpanW<S> span2{thetabk2, rhobk2,  gradbk2, logpbk2, thetafw2, rhofw2,
+                       gradfw2,  logpfw2, theta2,  grad2,   logp2};
 
   // following test fails in the original code with buggy uturn condition
   EXPECT_FALSE((nuts::uturn<nuts::Direction::Forward, S, nuts::SpanW<S>>(


### PR DESCRIPTION
Suggested in https://github.com/flatironinstitute/walnuts/pull/21#discussion_r2243819362, the tests previously needed to contort themselves to construct a Span.

This PR makes a small change to allow them to more easily construct them by turning the two existing constructors to the `Span` class into named factory methods. By not having any user defined constructors, `Span` is now a candidate for [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization.html). 
As an added benefit, I prefer how the code that uses these ends up reading, compared to the overloaded-constructor version. 