### PR TITLE
Convert acceptance rate of nan to 0 in dual averaging

### DIFF
--- a/include/walnuts/dual_average.hpp
+++ b/include/walnuts/dual_average.hpp
@@ -94,7 +94,7 @@ class DualAverage {
    * @pre alpha > 0
    */
   inline void observe(S alpha) noexcept {
-    if (std::isnan(alpha)) {
+    if (!std::isfinite(alpha)) {
       alpha = 0.0;
     }
     ++obs_count_;


### PR DESCRIPTION
While looking at #26 @bob-carpenter noticed it was possible for a model to have the parameters end up as nan and stay there forever. I tracked it down to this sequence of events:

1. One particularly bad trajectory during warmup ends up with the returned log density being `nan`
2. This nan value is used to compute an acceptance probability, which also ends up `nan`
3. The step size dual averaging parameters end up getting 'poisoned' by this nan
4. The next iteration, the step size itself is nan, which means after one gradient step, the parameters will be too.


I believe Stan traps this behavior here:
https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/hmc/nuts/base_nuts.hpp#L259-L260

Rather than do exactly what they do, I've moved this to inside the dual averaging. This moves it out of the code that we're relying on dead code optimization to handle for us when using the `NoOpHandler` in non-adaptive walnuts. 

I believe 0 is the correct value, working through what would happen if I did exactly what Stan did and set the bad energy value to inf, the acceptance probability would work out to exp(-inf) = 0