### PR TITLE
added min micro steps

### DIFF
--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -180,26 +180,25 @@ static void run_adaptive_walnuts(const F& target_logp_grad,
 
 int main() {
   unsigned int seed = 83435638;
-  Integer D = 200;
+  Integer D = 100;
   Integer N = 1000;
-  S step_size = 0.4;
-  Integer max_depth = 10;
-  Integer min_micro_steps = 4;
+  S step_size = 0.5;
+  Integer max_depth = 8;
+  Integer min_micro_steps = 3;
   S max_error = 1;  // 61% Metropolis
   VectorS inv_mass = VectorS::Ones(D);
   std::mt19937 rng(seed);
 
-  std::normal_distribution<S> std_normal(0, 1);
   VectorS theta_init(D);
+  std::normal_distribution<S> std_normal(0, 1);
   for (Integer i = 0; i < D; ++i) {
     theta_init(i) = std_normal(rng);
   }
+  // uncomment following to init at bottleneck
+  // theta_init = VectorS::Zero(D);
 
-  // alternatively, uncomment following to init at bottleneck
-  // VectorS theta_init = VectorS::Zero(D);
-
-  auto target_logp_grad = ill_cond_normal_logp_grad;
   // auto target_logp_grad = std_normal_logp_grad;
+  auto target_logp_grad = ill_cond_normal_logp_grad;
 
   run_nuts(target_logp_grad, theta_init, rng, D, N, step_size, max_depth,
            inv_mass);

--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -108,16 +108,19 @@ static void run_nuts(const F& target_logp_grad, const VectorS& theta_init,
 template <typename F, typename RNG>
 static void run_walnuts(const F& target_logp_grad, VectorS theta_init, RNG& rng,
                         Integer D, Integer N, S macro_step_size,
-                        Integer max_nuts_depth, S max_error, VectorS inv_mass) {
+                        Integer max_nuts_depth, Integer min_micro_steps,
+			S max_error, VectorS inv_mass) {
   std::cout << "\nRUN WALNUTS"
             << ";  D = " << D << ";  N = " << N
             << ";  macro_step_size = " << macro_step_size
             << ";  max_nuts_depth = " << max_nuts_depth
+	    << ";  min_micro_steps = " << min_micro_steps
             << ";  max_error = " << max_error << std::endl;
   global_start_timer();
   nuts::Random<double, RNG> rand(rng);
   nuts::WalnutsSampler sample(rand, target_logp_grad, theta_init, inv_mass,
-                              macro_step_size, max_nuts_depth, max_error);
+                              macro_step_size, max_nuts_depth, min_micro_steps,
+			      max_error);
   MatrixS draws(D, N);
   for (Integer n = 0; n < N; ++n) {
     draws.col(n) = sample();
@@ -129,7 +132,9 @@ static void run_walnuts(const F& target_logp_grad, VectorS theta_init, RNG& rng,
 template <typename F, typename RNG>
 static void run_adaptive_walnuts(const F& target_logp_grad,
                                  const VectorS& theta_init, RNG& rng, Integer D,
-                                 Integer N, Integer max_nuts_depth,
+                                 Integer N, double step_size_init,
+				 Integer max_nuts_depth,
+				 Integer min_micro_steps,
                                  S max_error) {
   Eigen::VectorXd mass_init = Eigen::VectorXd::Ones(D);
   double init_count = 1.1;
@@ -137,7 +142,6 @@ static void run_adaptive_walnuts(const F& target_logp_grad,
   double additive_smoothing = 0.1;
   nuts::MassAdaptConfig mass_cfg(mass_init, init_count, mass_iteration_offset,
                                  additive_smoothing);
-  double step_size_init = 0.5;
   double accept_rate_target = 2.0 / 3.0;
   double step_iteration_offset = 2.0;
   double learning_rate = 0.95;
@@ -146,11 +150,13 @@ static void run_adaptive_walnuts(const F& target_logp_grad,
                                  step_iteration_offset, learning_rate,
                                  decay_rate);
   Integer max_step_depth = 8;
-  nuts::WalnutsConfig walnuts_cfg(max_error, max_nuts_depth, max_step_depth);
+  nuts::WalnutsConfig walnuts_cfg(max_error, max_nuts_depth, max_step_depth,
+				  min_micro_steps);
   std::cout << "\nRUN ADAPTIVE WALNUTS"
             << ";  D = " << D << ";  N = " << N
             << "; step_size_init = " << step_size_init
             << "; max_nuts_depth = " << max_nuts_depth
+	    << "; min_micro_steps = " << min_micro_steps
             << "; max_error = " << max_error << std::endl;
   global_start_timer();
   nuts::AdaptiveWalnuts walnuts(rng, target_logp_grad, theta_init, mass_cfg,
@@ -166,19 +172,20 @@ static void run_adaptive_walnuts(const F& target_logp_grad,
   global_end_timer();
   summarize(draws);
   std::cout << std::endl;
-  std::cout << "Macro step size = " << sampler.macro_step_size() << std::endl;
+  std::cout << "Initial micro step size = " << sampler.macro_step_size() << std::endl;
   std::cout << "Max error = " << sampler.max_error() << std::endl;
   std::cout << "Inverse mass matrix = "
             << sampler.inverse_mass_matrix_diagonal().transpose() << std::endl;
 }
 
 int main() {
-  unsigned int seed = 428763;
+  unsigned int seed = 83435638;
   Integer D = 200;
   Integer N = 1000;
-  S step_size = 0.5;
+  S step_size = 0.4;
   Integer max_depth = 10;
-  S max_error = 1.0;  // 61% Metropolis
+  Integer min_micro_steps = 4;
+  S max_error = 1;  // 61% Metropolis
   VectorS inv_mass = VectorS::Ones(D);
   std::mt19937 rng(seed);
 
@@ -198,10 +205,10 @@ int main() {
            inv_mass);
 
   run_walnuts(target_logp_grad, theta_init, rng, D, N, step_size, max_depth,
-              max_error, inv_mass);
+              min_micro_steps, max_error, inv_mass);
 
-  run_adaptive_walnuts(target_logp_grad, theta_init, rng, D, N, max_depth,
-                       max_error);
+  run_adaptive_walnuts(target_logp_grad, theta_init, rng, D, N, step_size,
+		       max_depth, min_micro_steps, max_error);
 
   return 0;
 }

--- a/examples/stan_cli.cpp
+++ b/examples/stan_cli.cpp
@@ -224,7 +224,7 @@ int main(int argc, char** argv) {
 
     app.add_option("--min-micro-steps", min_micro_steps,
                    "Minimum micro steps per macro step")
-        ->default_val(num_micro_steps)
+        ->default_val(min_micro_steps)
         ->check(CLI::PositiveNumber);
 
     app.add_option("--max-error", max_error,

--- a/include/walnuts/adaptive_walnuts.hpp
+++ b/include/walnuts/adaptive_walnuts.hpp
@@ -193,24 +193,31 @@ struct WalnutsConfig {
    * doublings for NUTS.
    * @param[in] max_step_depth The maximum number of step doublings
    * per macro step.
+   * @param[in] min_micro_steps The minimum number of micro steps per macro
+   *  step.
    * @throw std::invalid_argument If the log max error is not finite and
    * positive.
    * @throw std::invalid_argument If the maximum tree depth is not positive.
    * @throw std::invalid_argument If the maximum step depth is negative.
    */
-  WalnutsConfig(S log_max_error, Integer max_nuts_depth, Integer max_step_depth)
+  WalnutsConfig(S log_max_error, Integer max_nuts_depth, Integer max_step_depth,
+		Integer min_micro_steps)
       : log_max_error_(log_max_error),
         max_nuts_depth_(max_nuts_depth),
-        max_step_depth_(max_step_depth) {
+        max_step_depth_(max_step_depth),
+	min_micro_steps_(min_micro_steps) {
     if (!(log_max_error > 0) || std::isinf(log_max_error)) {
       throw std::invalid_argument(
           "Log maximum error must be positive and finite.");
     }
-    if (max_nuts_depth < 1) {
+    if (max_nuts_depth <= 0) {
       throw std::invalid_argument("Maximum NUTS depth must be positive.");
     }
     if (max_step_depth < 0) {
       throw std::invalid_argument("Maximum step depth must be non-negative.");
+    }
+    if (min_micro_steps <= 0) {
+      throw std::invalid_argument("Minimum micro steps must be positive.");
     }
   }
 
@@ -222,6 +229,9 @@ struct WalnutsConfig {
 
   /** The maximum number of step doublings per macro step. */
   const Integer max_step_depth_;
+
+  /** The minimum number of micro steps per macro step. */
+  const Integer min_micro_steps_;
 };
 
 /**
@@ -486,7 +496,8 @@ class AdaptiveWalnuts {
     Vec<S> grad_select;
     theta_ = transition_w(
         rand_, logp_grad_, inv_mass, chol_mass, step_adapt_handler_.step_size(),
-        walnuts_cfg_.max_nuts_depth_, std::move(theta_), grad_select,
+        walnuts_cfg_.max_nuts_depth_, walnuts_cfg_.min_micro_steps_,
+	std::move(theta_), grad_select,
         walnuts_cfg_.log_max_error_, step_adapt_handler_);
     mass_estimator_.observe(theta_, grad_select, iteration_);
     ++iteration_;
@@ -507,7 +518,8 @@ class AdaptiveWalnuts {
     return WalnutsSampler<F, S, RNG>(
         rand_, logp_grad_.logp_grad_, theta_,
         mass_estimator_.inv_mass_estimate(), step_adapt_handler_.step_size(),
-        walnuts_cfg_.max_nuts_depth_, walnuts_cfg_.log_max_error_);
+        walnuts_cfg_.max_nuts_depth_, walnuts_cfg_.min_micro_steps_,
+	walnuts_cfg_.log_max_error_);
   }
 
   /**

--- a/include/walnuts/dual_average.hpp
+++ b/include/walnuts/dual_average.hpp
@@ -62,7 +62,7 @@ class DualAverage {
         log_est_avg_(log_est_),
         grad_avg_(0),
         obs_count_(0),
-        log_step_offset_(std::log(1) + std::log(step_size_init)),
+        log_step_offset_(std::log(10) + std::log(step_size_init)),
         target_accept_rate_(target_accept_rate),
         obs_count_offset_(obs_count_offset),
         learn_rate_(learn_rate),

--- a/include/walnuts/dual_average.hpp
+++ b/include/walnuts/dual_average.hpp
@@ -62,7 +62,7 @@ class DualAverage {
         log_est_avg_(log_est_),
         grad_avg_(0),
         obs_count_(0),
-        log_step_offset_(std::log(10) + std::log(step_size_init)),
+        log_step_offset_(std::log(1) + std::log(step_size_init)),
         target_accept_rate_(target_accept_rate),
         obs_count_offset_(obs_count_offset),
         learn_rate_(learn_rate),

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -153,7 +153,8 @@ bool within_tolerance(const F& logp_grad, const Vec<S>& inv_mass, S step,
  * @param[in] logp_grad The log density/gradient function.
  * @param[in] inv_mass The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The micro step size.
- * @param[in] num_steps The number of micro steps to take.
+ * @param[in] num_steps The number of micro steps proposed forward.
+ * @param[in] min_micro_steps The minimum number of micro steps to take.
  * @param[in] max_error The maximum error tolerance in Hessians.
  * @param[in] logp_next The log density of the starting position.
  * @param[in] theta The final position from which to reverse.
@@ -163,7 +164,7 @@ bool within_tolerance(const F& logp_grad, const Vec<S>& inv_mass, S step,
  */
 template <typename S, typename F>
 bool reversible(const F& logp_grad, const Vec<S>& inv_mass, S step,
-                Integer num_steps, S max_error, S logp_next,
+                Integer num_steps, Integer min_micro_steps, S max_error, S logp_next,
                 const Vec<S>& theta, const Vec<S>& rho, const Vec<S>& grad) {
   if (num_steps == 1) {
     return true;
@@ -171,7 +172,7 @@ bool reversible(const F& logp_grad, const Vec<S>& inv_mass, S step,
   Vec<S> theta_next(grad.size());
   Vec<S> rho_next(rho.size());
   Vec<S> grad_next(grad.size());
-  while (num_steps >= 2) {
+  while (num_steps > 2 * min_micro_steps) {
     theta_next = theta;
     rho_next = -rho;
     grad_next = grad;
@@ -239,8 +240,8 @@ bool macro_step(const F& logp_grad, const Vec<S>& inv_mass, S step,
       adapt_handler(min_accept);
     }
     if (std::fabs(logp - logp_next) <= max_error) {
-      return reversible(logp_grad, inv_mass, step, num_steps, max_error,
-                        logp_next, theta_next, rho_next, grad_next);
+      return reversible(logp_grad, inv_mass, step, num_steps, min_micro_steps,
+			max_error, logp_next, theta_next, rho_next, grad_next);
     }
   }
   return false;


### PR DESCRIPTION
I added a minimum number of micro steps parameter.  I'm not trying to auto-tune it yet. 

There's some kind of bug in my evaluation code, I think.  But I haven't been able to track it down.  Clues:

* `WalnutsSampler` doesn't work unless `min_micro_steps = 1`
* `AdaptiveWalnutsSampler` works with just about any `min_micro_steps`.  

If `WalnutSampler` doesn't work, then `AdaptiveWalnutsSampler` shouldn't work either, as it calls `WalnutsSampler` to do the sampling.  I added prints at one point to make sure that `AdaptiveWalnutsSampler` passes the min number of micro steps and that it's being used.  So I can only imagine that I'm calling `WalnutsSampler` correctly when created in `AdaptiveWalnutsSampler` but incorrectly when called directly.  Or maybe it's just because it doesn't adapt the mass matrix, so it really struggles? 

I would like to get the `WalnutsSampler` working on its own before merging, but I'm not clear on where to go next in debugging.
