### PR TITLE
Avoid using long int type, prefer Eigen::Index

### DIFF
--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -64,9 +64,9 @@ static void std_normal_logp_grad(const Eigen::VectorXd& x, double& logp,
 }
 
 static void summarize(const Eigen::MatrixXd& draws) {
-  long N = draws.cols();
-  long D = draws.rows();
-  for (long d = 0; d < D; ++d) {
+  auto N = draws.cols();
+  auto D = draws.rows();
+  for (auto d = 0; d < D; ++d) {
     if (d > 3 && d < D - 3) {
       if (d == 4) {
         std::cout << "... elided " << (D - 6) << " rows ..." << std::endl;
@@ -94,9 +94,10 @@ static void run_nuts(const F& target_logp_grad,
   nuts::Random<double, RNG> rand(rng);
   nuts::Nuts sample(rand, target_logp_grad, theta_init, inv_mass, step_size,
                     max_depth);
-  Eigen::MatrixXd draws(static_cast<long>(D), static_cast<long>(N));
+  Eigen::MatrixXd draws(static_cast<Eigen::Index>(D),
+                        static_cast<Eigen::Index>(N));
   for (std::size_t n = 0; n < N; ++n) {
-    draws.col(static_cast<long>(n)) = sample();
+    draws.col(static_cast<Eigen::Index>(n)) = sample();
   }
   global_end_timer();
   summarize(draws);
@@ -122,7 +123,7 @@ static void run_walnuts(const F& target_logp_grad, Eigen::VectorXd theta_init,
                               max_step_halvings, min_micro_steps, max_error);
   Eigen::MatrixXd draws(D, N);
   for (std::size_t n = 0; n < N; ++n) {
-    draws.col(static_cast<long>(n)) = sample();
+    draws.col(static_cast<Eigen::Index>(n)) = sample();
   }
   global_end_timer();
   summarize(draws);
@@ -133,7 +134,8 @@ static void run_adaptive_walnuts(
     const F& target_logp_grad, const Eigen::VectorXd& theta_init, RNG& rng,
     std::size_t D, std::size_t N, double step_size_init,
     std::size_t max_nuts_depth, std::size_t min_micro_steps, double max_error) {
-  Eigen::VectorXd mass_init = Eigen::VectorXd::Ones(static_cast<long>(D));
+  Eigen::VectorXd mass_init =
+      Eigen::VectorXd::Ones(static_cast<Eigen::Index>(D));
   double init_count = 1.1;
   double mass_iteration_offset = 1.1;
   double additive_smoothing = 0.1;
@@ -164,9 +166,10 @@ static void run_adaptive_walnuts(
     walnuts();
   }
   auto sampler = walnuts.sampler();
-  Eigen::MatrixXd draws(static_cast<long>(D), static_cast<long>(N));
+  Eigen::MatrixXd draws(static_cast<Eigen::Index>(D),
+                        static_cast<Eigen::Index>(N));
   for (std::size_t n = 0; n < N; ++n) {
-    draws.col(static_cast<long>(n)) = sampler();
+    draws.col(static_cast<Eigen::Index>(n)) = sampler();
   }
   global_end_timer();
   summarize(draws);
@@ -187,13 +190,14 @@ int main() {
   std::size_t max_step_halvings = 5;
   std::size_t min_micro_steps = 3;
   double max_error = 1;  // 61% Metropolis
-  Eigen::VectorXd inv_mass = Eigen::VectorXd::Ones(static_cast<long>(D));
+  Eigen::VectorXd inv_mass =
+      Eigen::VectorXd::Ones(static_cast<Eigen::Index>(D));
   std::mt19937 rng(seed);
 
   Eigen::VectorXd theta_init(D);
   std::normal_distribution<double> std_normal(0, 1);
   for (std::size_t i = 0; i < D; ++i) {
-    theta_init(static_cast<long>(i)) = std_normal(rng);
+    theta_init(static_cast<Eigen::Index>(i)) = std_normal(rng);
   }
   // uncomment following to init at bottleneck
   // theta_init = ::Zero(D);

--- a/examples/examples_stan.cpp
+++ b/examples/examples_stan.cpp
@@ -17,9 +17,9 @@ using MatrixS = Eigen::Matrix<S, -1, -1>;
 
 static void summarize(const std::vector<std::string> names,
                       const MatrixS& draws) {
-  long N = draws.cols();
-  long D = draws.rows();
-  for (long d = 0; d < D; ++d) {
+  auto N = draws.cols();
+  auto D = draws.rows();
+  for (auto d = 0; d < D; ++d) {
     if (d > 3 && d < D - 3) {
       if (d == 4) {
         std::cout << "... elided " << (D - 6) << " rows ..." << std::endl;
@@ -61,7 +61,7 @@ static void test_nuts(const DynamicStanModel& model, const VectorS& theta_init,
 
   MatrixS draws(M, N);
   for (std::size_t n = 0; n < N; ++n) {
-    model.constrain_draw(sample(), draws.col(static_cast<long>(n)));
+    model.constrain_draw(sample(), draws.col(static_cast<Eigen::Index>(n)));
   }
 
   auto global_end = std::chrono::high_resolution_clock::now();
@@ -95,9 +95,9 @@ static void test_walnuts(const DynamicStanModel& model,
                               min_micro_steps, log_max_error);
   std::size_t M = model.constrained_dimensions();
 
-  MatrixS draws(static_cast<long>(M), static_cast<long>(N));
+  MatrixS draws(static_cast<Eigen::Index>(M), static_cast<Eigen::Index>(N));
   for (std::size_t n = 0; n < N; ++n) {
-    model.constrain_draw(sample(), draws.col(static_cast<long>(n)));
+    model.constrain_draw(sample(), draws.col(static_cast<Eigen::Index>(n)));
   }
   summarize(model.param_names(), draws);
 }
@@ -112,7 +112,7 @@ static void test_adaptive_walnuts(const DynamicStanModel& model,
   std::size_t logp_count = 0;
   auto global_start = std::chrono::high_resolution_clock::now();
 
-  Eigen::VectorXd mass_init = Eigen::VectorXd::Ones(static_cast<long>(D));
+  Eigen::VectorXd mass_init = Eigen::VectorXd::Ones(static_cast<Eigen::Index>(D));
   double init_count = 1.1;
   double mass_iteration_offset = 1.1;
   double additive_smoothing = 0.1;
@@ -173,7 +173,7 @@ static void test_adaptive_walnuts(const DynamicStanModel& model,
 
   MatrixS draws(M, N);
   for (std::size_t n = 0; n < N; ++n) {
-    model.constrain_draw(sampler(), draws.col(static_cast<long>(n)));
+    model.constrain_draw(sampler(), draws.col(static_cast<Eigen::Index>(n)));
   }
 
   global_end = std::chrono::high_resolution_clock::now();
@@ -216,7 +216,7 @@ int main(int argc, char** argv) {
   DynamicStanModel model(lib, data, seed);
 
   std::size_t D = model.unconstrained_dimensions();
-  VectorS inv_mass = VectorS::Ones(static_cast<long>(D));
+  VectorS inv_mass = VectorS::Ones(static_cast<Eigen::Index>(D));
 
   std::cout << "SHARED CONSTANTS:" << std::endl;
   std::cout << "D = " << D << ";  N = " << N << ";  step_size = " << step_size
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
   std::normal_distribution<S> std_normal(0.0, 1.0);
   VectorS theta_init(D);
   for (std::size_t i = 0; i < D; ++i) {
-    theta_init(static_cast<long>(i)) = std_normal(rng);
+    theta_init(static_cast<Eigen::Index>(i)) = std_normal(rng);
   }
 
   test_nuts(model, theta_init, rng, N, step_size, max_depth, inv_mass);

--- a/include/walnuts/online_moments.hpp
+++ b/include/walnuts/online_moments.hpp
@@ -68,8 +68,8 @@ class OnlineMoments {
   OnlineMoments(double discount_factor, std::size_t dims)
       : discount_factor_(discount_factor),
         weight_(0),
-        mean_(Vec<S>::Zero(static_cast<long>(dims))),
-        sum_sq_dev_(Vec<S>::Zero(static_cast<long>(dims))) {}
+        mean_(Vec<S>::Zero(static_cast<Eigen::Index>(dims))),
+        sum_sq_dev_(Vec<S>::Zero(static_cast<Eigen::Index>(dims))) {}
 
   /**
    * @brief Construct an online estimator of moments with the

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -97,7 +97,7 @@ class Random {
    * @return A vector generated according to a standard normal distribution.
    */
   inline Vec<S> standard_normal(std::size_t n) {
-    long n_signed = static_cast<long>(n);
+    auto n_signed = static_cast<Eigen::Index>(n);
     return Vec<S>::NullaryExpr(n_signed,
                                [&](std::size_t) { return normal_(rng_); });
   }

--- a/tests/online_moments_test.cpp
+++ b/tests/online_moments_test.cpp
@@ -31,7 +31,7 @@ static Eigen::VectorXd discounted_variance(
   std::size_t D = static_cast<std::size_t>(ys[0].size());
   double weight_sum = 0;
   Eigen::VectorXd weighted_sq_diff_sum =
-      Eigen::VectorXd::Zero(static_cast<long>(D));
+      Eigen::VectorXd::Zero(static_cast<Eigen::Index>(D));
   for (std::size_t n = 0; n < N; ++n) {
     double weight = std::pow(alpha, N - n - 1);
     weight_sum += weight;
@@ -81,20 +81,21 @@ TEST(Welford, test_no_discounting) {
   std::size_t N = 100;
   std::vector<Eigen::VectorXd> ys(N);
   for (std::size_t n = 0; n < N; ++n) {
-    ys[n] = Eigen::VectorXd::Zero(static_cast<long>(D));
+    ys[n] = Eigen::VectorXd::Zero(static_cast<Eigen::Index>(D));
   }
   for (std::size_t n = 0; n < N; ++n) {
     double x = static_cast<double>(n);
     ys[n] << x, std::sqrt(x);
   }
 
-  Eigen::VectorXd sum = Eigen::VectorXd::Zero(static_cast<long>(D));
+  Eigen::VectorXd sum = Eigen::VectorXd::Zero(static_cast<Eigen::Index>(D));
   for (auto y : ys) {
     sum += y;
   }
   Eigen::VectorXd mean_expected = sum / N;
 
-  Eigen::VectorXd sum_sq_diffs = Eigen::VectorXd::Zero(static_cast<long>(D));
+  Eigen::VectorXd sum_sq_diffs =
+      Eigen::VectorXd::Zero(static_cast<Eigen::Index>(D));
   for (auto y : ys) {
     sum_sq_diffs +=
         ((y - mean_expected).array() * (y - mean_expected).array()).matrix();
@@ -119,7 +120,7 @@ TEST(Welford, test_ten_observations) {
   std::size_t N = 10;
   std::vector<Eigen::VectorXd> ys(N);
   for (std::size_t n = 0; n < N; ++n) {
-    ys[n] = Eigen::VectorXd::Zero(static_cast<long>(D));
+    ys[n] = Eigen::VectorXd::Zero(static_cast<Eigen::Index>(D));
   }
   for (std::size_t n = 0; n < N; ++n) {
     double x = static_cast<double>(n);


### PR DESCRIPTION
Follow on to #40.

`long` is always 4 bytes on Windows, but is either 4 or 8 bytes on Linux or Mac depending on if your machine is 32 or 64 bit. Especially because we're using it to interface with Eigen, the correct thing to do to avoid this whole mess is just use the Eigen::Index type directly.

I'm honestly not sure how many of these static casts are necessary, and I generally find this all to be such a language wart, but I've left them in place.