### PR TITLE
stop building googlemock to work around bug in latest commit upstream

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ if(MSVC)
   set(gtest_force_shared_crt on)
 endif()
 
+set(BUILD_GMOCK OFF CACHE BOOL "Disable building Google Mock" FORCE)
 FetchContent_Declare(googletest
         DOWNLOAD_EXTRACT_TIMESTAMP ON
         GIT_REPOSITORY https://github.com/google/googletest.git


### PR DESCRIPTION
I believe this is due to an issue in https://github.com/google/googletest/commit/065127f1e4b46c5f14fc73cf8d323c221f9dc68e, (see https://github.com/google/googletest/issues/4881). 

At any rate, we aren't using googlemock, and this fixes the broken Windows build. 