### PR TITLE
adds concepts and attributes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(walnuts
 )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 if (CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -177,7 +177,7 @@ endif()
 #################################
 if (WALNUTS_BUILD_DOCS)
   find_package(Doxygen REQUIRED)
-
+  if (DOXYGEN_FOUND)
   # Public headers only
   file(GLOB_RECURSE WALNUT_HEADERS
       "${CMAKE_CURRENT_SOURCE_DIR}/include/walnuts/*.hpp")
@@ -194,4 +194,7 @@ if (WALNUTS_BUILD_DOCS)
     ${WALNUT_HEADERS}           # INPUT files
     COMMENT "Generate API documentation in ${DOXYGEN_OUTPUT_DIRECTORY}"
   )
+  else()
+    message(WARNING "Doxygen not found. 'doc' target will not be available.")
+  endif()
 endif()

--- a/include/walnuts/adaptive_walnuts.hpp
+++ b/include/walnuts/adaptive_walnuts.hpp
@@ -6,19 +6,20 @@
 #include "online_moments.hpp"
 #include "util.hpp"
 #include "walnuts.hpp"
-
+#include <walnuts/attributes.hpp>
+#include <walnuts/concepts.hpp>
 namespace nuts {
 
 /**
  * @brief Return the gradient of the log density at the specified position.
  *
  * @tparam S The type of scalars.
- * @tparam F The type of the target log density/gradient function.
+ * @tparam F A callable type for the target log density/gradient function.
  * @param[in] logp_grad The target log density/gradient function.
  * @param[in] theta The position at which to evaluate the gradient.
  * @return The gradient of the log density at `theta`.
  */
-template <typename S, class F>
+template <FloatingPoint S, LogGradFun<S> F>
 Vec<S> grad(const F& logp_grad, const Vec<S>& theta) {
   Vec<S> g;
   S logp;
@@ -38,12 +39,12 @@ Vec<S> grad(const F& logp_grad, const Vec<S>& theta) {
  *
  * @tparam S The type of scalars.
  */
-template <typename S>
+template <FloatingPoint S>
 struct MassAdaptConfig {
   /**
    * @brief Construct a mass adaptation configuration with the specified
    * tuning parameters.
-   *
+   * @tparam MassInit An Eigen vector type
    * @param[in] mass_init The diagonal of the diagonal initial mass matrix.
    * @param[in] init_count The pseudocount of observations for the
    * initialization.
@@ -58,9 +59,10 @@ struct MassAdaptConfig {
    * positive.
    * @throw std::invalid_argument If the additive smoothing is not in (0, 1).
    */
-  MassAdaptConfig(const Vec<S>& mass_init, S init_count, S iter_offset,
+  template <EigenVector MassInit>
+  MassAdaptConfig(MassInit&& mass_init, S init_count, S iter_offset,
                   S additive_smoothing)
-      : mass_init_(mass_init),
+      : mass_init_(std::forward<MassInit>(mass_init)),
         init_count_(init_count),
         iter_offset_(iter_offset),
         additive_smoothing_(additive_smoothing) {
@@ -97,7 +99,7 @@ struct MassAdaptConfig {
  *
  * @tparam S The type of scalars.
  */
-template <typename S>
+template <FloatingPoint S>
 struct WalnutsConfig {
   /**
    * @brief Construct a WALNUTS configuration with the specified
@@ -148,7 +150,7 @@ struct WalnutsConfig {
  *
  * @tparam S The type of scalars.
  */
-template <typename S>
+template <FloatingPoint S>
 class StepAdaptHandler {
  public:
   /**
@@ -184,7 +186,7 @@ class StepAdaptHandler {
  *
  * @tparam S The type of scalars.
  */
-template <typename S>
+template <FloatingPoint S>
 class MassEstimator {
  public:
   /**
@@ -206,7 +208,7 @@ class MassEstimator {
    * and the variance of the draws (the variance estimator).  This estimate
    * is then additively smoothed by multiplying by multiplying by one minus
    * the additive smoothing and adding the additive smoothing.
-   *
+   * @tparam MassConfig `MassAdaptConfig<S>`. Template used here for perfect forwarding.
    * @param[in] mass_cfg The mass matrix adaptation configuration.
    * @param[in] theta The initial position.
    * @param[in] grad The gradient of the target log density at the initial
@@ -214,9 +216,11 @@ class MassEstimator {
    * @throw std::invalid_argument If the position and gradient are not the same
    * size.
    */
-  MassEstimator(const MassAdaptConfig<S>& mass_cfg, const Vec<S>& theta,
+  template <typename MassConfig>
+  requires(std::same_as<std::decay_t<MassConfig>, MassAdaptConfig<S>>)
+  MassEstimator(MassConfig&& mass_cfg, const Vec<S>& theta,
                 const Vec<S>& grad)
-      : mass_cfg_(mass_cfg) {
+      : mass_cfg_(std::forward<MassConfig>(mass_cfg)) {
     // 0.98 is dummy that will get overwritten
     // var_estimator_(0.98, static_cast<std::size_t>(theta.size())),
     // inv_var_estimator_(0.98, static_cast<std::size_t>(theta.size())) {
@@ -360,7 +364,7 @@ class MinMicroStepsAdaptHandler {
  * @tparam S Type of scalars.
  * @tparam RNG Type of base random number generator.
  */
-template <class F, typename S, class RNG>
+template <FloatingPoint S, LogGradFun<S> F, class RNG>
 class AdaptiveWalnuts {
  public:
   /**
@@ -376,6 +380,8 @@ class AdaptiveWalnuts {
    * the minimum number of micro steps per macro step and adjusted with
    * a mean estimator to achieve this average.
    *
+   * @tparam FF Callable type for the log density and gradient function.
+   * @tparam ThetaInit Eigen vector type
    * @param[in,out] rng The base random number generator.
    * @param[in] logp_grad The target log density and gradient function.
    * @param[in] theta_init The initial state.
@@ -384,7 +390,9 @@ class AdaptiveWalnuts {
    * @param[in] walnuts_cfg The WALNUTS configuration.
    * @param[in] target_depth The target expected NUTS tree depth.
    */
-  AdaptiveWalnuts(RNG& rng, const F& logp_grad, const Vec<S>& theta_init,
+  template <LogGradFun<S> FF, EigenVector ThetaInit>
+  requires(std::same_as<std::decay_t<FF>, F>)
+  AdaptiveWalnuts(RNG& rng, FF&& logp_grad, ThetaInit&& theta_init,
                   const MassAdaptConfig<S>& mass_cfg,
                   const AdamConfig<S>& step_cfg,
                   const WalnutsConfig<S>& walnuts_cfg,
@@ -393,8 +401,8 @@ class AdaptiveWalnuts {
         step_cfg_(step_cfg),
         walnuts_cfg_(walnuts_cfg),
         rand_(rng),
-        logp_grad_(logp_grad),
-        theta_(theta_init),
+        logp_grad_(std::forward<FF>(logp_grad)),
+        theta_(std::forward<ThetaInit>(theta_init)),
         iteration_(0),
         step_adapt_handler_(step_cfg),
         mass_estimator_(mass_cfg_, theta_, grad(logp_grad, theta_)),
@@ -437,12 +445,11 @@ class AdaptiveWalnuts {
    *
    * @return The WALNUTS sampler with current tuning parameter estimates.
    */
-  WalnutsSampler<F, S, RNG> sampler() {
-    return WalnutsSampler<F, S, RNG>(
-        rand_, logp_grad_.logp_grad_, theta_,
+  auto sampler() {
+    return WalnutsSampler{rand_, logp_grad_.logp_grad_, theta_,
         mass_estimator_.inv_mass_estimate(), step_adapt_handler_.step_size(),
         walnuts_cfg_.max_nuts_depth_, walnuts_cfg_.max_step_halvings_,
-        min_micro_estimator_.min_micro_steps(), walnuts_cfg_.max_error_);
+        min_micro_estimator_.min_micro_steps(), walnuts_cfg_.max_error_};
   }
 
   /**
@@ -450,7 +457,7 @@ class AdaptiveWalnuts {
    *
    * @return The diagonal of the inverse mass matrix.
    */
-  Vec<S> inv_mass() const { return mass_estimator_.inv_mass_estimate(); }
+  EigenVector auto inv_mass() const { return mass_estimator_.inv_mass_estimate(); }
 
   /**
    * @brief Return the step size.
@@ -500,5 +507,12 @@ class AdaptiveWalnuts {
   /** The estimator for the minimum number of micro steps per macro step. */
   MinMicroStepsAdaptHandler min_micro_estimator_;
 };
+// CTAD deduction guide
+template <FloatingPoint S, LogGradFun<S> FF, typename RNG>
+AdaptiveWalnuts(RNG& rng, const FF& logp_grad, const Vec<S>& theta_init,
+                const MassAdaptConfig<S>& mass_cfg,
+                const AdamConfig<S>& step_cfg,
+                const WalnutsConfig<S>& walnuts_cfg,
+                double target_depth = 4.0) -> AdaptiveWalnuts<S, std::decay_t<FF>, RNG>;
 
 }  // namespace nuts

--- a/include/walnuts/attributes.hpp
+++ b/include/walnuts/attributes.hpp
@@ -1,24 +1,49 @@
 #pragma once
+
+/**
+ * Forces function to not be inline eligible
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-noinline-function-attribute
+ **/
 #ifndef WALNUTS_NO_INLINE_
 #define WALNUTS_NO_INLINE_ __attribute__((noinline))
 #endif
 
+/**
+ * Compiler will attempt to inline this function more
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-always_005finline-function-attribute
+ **/
 #ifndef WALNUTS_ALWAYS_INLINE_
 #define WALNUTS_ALWAYS_INLINE_ __attribute__((always_inline)) inline
 #endif
 
+/**
+ * Compiler treats function as hot spot and optimizes more aggressively
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-hot-function-attribute
+ **/
 #ifndef WALNUTS_HOT_
 #define WALNUTS_HOT_ __attribute__((hot))
 #endif
 
+/**
+ * Place function on the cold path for the compiler. Useful for functions that construct error messages etc.
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-cold-function-attribute
+ **/
 #ifndef WALNUTS_COLD_
 #define WALNUTS_COLD_ __attribute__((cold))
 #endif
 
+/**
+ * Compiler will attempt to inline everything inside of the function
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-flatten-function-attribute
+ **/
 #ifndef WALNUTS_FLATTEN_
 #define WALNUTS_FLATTEN_ __attribute__((flatten))
 #endif
 
+/**
+ * For defining a function as pure
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-pure-function-attribute
+ **/
 #ifndef WALNUTS_PURE_
 #define WALNUTS_PURE_ __attribute__((pure))
 #endif

--- a/include/walnuts/attributes.hpp
+++ b/include/walnuts/attributes.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#ifndef WALNUTS_NO_INLINE_
+#define WALNUTS_NO_INLINE_ __attribute__((noinline))
+#endif
+
+#ifndef WALNUTS_ALWAYS_INLINE_
+#define WALNUTS_ALWAYS_INLINE_ __attribute__((always_inline)) inline
+#endif
+
+#ifndef WALNUTS_HOT_
+#define WALNUTS_HOT_ __attribute__((hot))
+#endif
+
+#ifndef WALNUTS_COLD_
+#define WALNUTS_COLD_ __attribute__((cold))
+#endif
+
+#ifndef WALNUTS_FLATTEN_
+#define WALNUTS_FLATTEN_ __attribute__((flatten))
+#endif
+
+#ifndef WALNUTS_PURE_
+#define WALNUTS_PURE_ __attribute__((pure))
+#endif
+
+#ifndef likely
+#define likely(x) __builtin_expect((x), 1)
+#endif
+
+#ifndef unlikely
+#define unlikely(x) __builtin_expect((x), 0)
+#endif

--- a/include/walnuts/attributes.hpp
+++ b/include/walnuts/attributes.hpp
@@ -25,7 +25,8 @@
 #endif
 
 /**
- * Place function on the cold path for the compiler. Useful for functions that construct error messages etc.
+ * Place function on the cold path for the compiler. Useful for functions that
+ *construct error messages etc.
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-cold-function-attribute
  **/
 #ifndef WALNUTS_COLD_

--- a/include/walnuts/attributes.hpp
+++ b/include/walnuts/attributes.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
+#ifdef __has_attribute
 /**
  * Forces function to not be inline eligible
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-noinline-function-attribute
  **/
 #ifndef WALNUTS_NO_INLINE_
-#define WALNUTS_NO_INLINE_ __attribute__((noinline))
+  #if __has_attribute(noinline)
+  #define WALNUTS_NO_INLINE_ __attribute__((noinline))
+  #else
+  #define WALNUTS_NO_INLINE_
+  #endif
 #endif
 
 /**
@@ -13,7 +18,11 @@
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-always_005finline-function-attribute
  **/
 #ifndef WALNUTS_ALWAYS_INLINE_
-#define WALNUTS_ALWAYS_INLINE_ __attribute__((always_inline)) inline
+  #if __has_attribute(always_inline)
+  #define WALNUTS_ALWAYS_INLINE_ __attribute__((always_inline)) inline
+  #else
+  #define WALNUTS_ALWAYS_INLINE_ inline
+  #endif
 #endif
 
 /**
@@ -21,7 +30,11 @@
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-hot-function-attribute
  **/
 #ifndef WALNUTS_HOT_
-#define WALNUTS_HOT_ __attribute__((hot))
+  #if __has_attribute(hot)
+  #define WALNUTS_HOT_ __attribute__((hot))
+  #else
+  #define WALNUTS_HOT_
+  #endif
 #endif
 
 /**
@@ -30,7 +43,11 @@
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-cold-function-attribute
  **/
 #ifndef WALNUTS_COLD_
-#define WALNUTS_COLD_ __attribute__((cold))
+  #if __has_attribute(cold)
+  #define WALNUTS_COLD_ __attribute__((cold))
+  #else
+  #define WALNUTS_COLD_
+  #endif
 #endif
 
 /**
@@ -38,7 +55,11 @@
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-flatten-function-attribute
  **/
 #ifndef WALNUTS_FLATTEN_
-#define WALNUTS_FLATTEN_ __attribute__((flatten))
+  #if __has_attribute(flatten)
+  #define WALNUTS_FLATTEN_ __attribute__((flatten))
+  #else
+  #define WALNUTS_FLATTEN_
+  #endif
 #endif
 
 /**
@@ -46,7 +67,11 @@
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-pure-function-attribute
  **/
 #ifndef WALNUTS_PURE_
+#if __has_attribute(pure)
 #define WALNUTS_PURE_ __attribute__((pure))
+#else
+#define WALNUTS_PURE_
+#endif
 #endif
 
 #ifndef likely
@@ -55,4 +80,6 @@
 
 #ifndef unlikely
 #define unlikely(x) __builtin_expect((x), 0)
+#endif
+
 #endif

--- a/include/walnuts/attributes.hpp
+++ b/include/walnuts/attributes.hpp
@@ -82,4 +82,37 @@
 #define unlikely(x) __builtin_expect((x), 0)
 #endif
 
+#else // ifdef __has_attribute
+
+#ifndef WALNUTS_NO_INLINE_
+#define WALNUTS_NO_INLINE_
 #endif
+
+#ifndef WALNUTS_ALWAYS_INLINE_
+#define WALNUTS_ALWAYS_INLINE_ inline
+#endif
+
+#ifndef WALNUTS_HOT_
+#define WALNUTS_HOT_
+#endif
+
+#ifndef WALNUTS_COLD_
+#define WALNUTS_COLD_
+#endif
+
+#ifndef WALNUTS_FLATTEN_
+#define WALNUTS_FLATTEN_
+#endif
+
+#ifndef WALNUTS_PURE_
+#define WALNUTS_PURE_
+#endif
+
+#ifndef likely
+#define likely(x) __builtin_expect((x), 1)
+#endif
+
+#ifndef unlikely
+#define unlikely(x) __builtin_expect((x), 0)
+#endif
+#endif // ifdef __has_attribute

--- a/include/walnuts/concepts.hpp
+++ b/include/walnuts/concepts.hpp
@@ -117,21 +117,24 @@ concept EigenMatrixBase = is_base_pointer_convertible_v<Eigen::MatrixBase, std::
 template <typename T>
 concept EigenDenseBase = is_base_pointer_convertible_v<Eigen::DenseBase, std::decay_t<T>>;
 
-// 1D (vector) vs 2D (matrix) using Eigen compile-time shape
+// 1D (vector) using Eigen compile-time shape
 template <typename T>
 concept EigenVector
     = EigenMatrixBase<T>
       && ((std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1) ||
           (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1));
 
+// Concept for a 1D column vector
 template <typename T>
 concept EigenColVector
-    = EigenMatrixBase<T> && (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1);
+    = EigenVector<T> && (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1);
 
+// Concept for a 1d row vector
 template <typename T>
 concept EigenRowVector
-    = EigenMatrixBase<T> && (std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1);
+    = EigenVector<T> && (std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1);
 
+// A 2d matrix
 template <typename T>
 concept EigenMatrix
     = EigenMatrixBase<T>

--- a/include/walnuts/concepts.hpp
+++ b/include/walnuts/concepts.hpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Kalshi DPDK Trading System
+
+#pragma once
+#include <Eigen/Dense>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <Eigen/Dense>
+/**
+ * @file concepts.hpp
+ * @brief C++20 concepts for compile-time interface checking
+ *
+ * @details This file defines concepts used across the trading system to enforce
+ * interface contracts at compile time. This provides zero-cost abstraction
+ * compared to runtime polymorphism via virtual functions.
+ *
+ * Design principles:
+ * - Concepts enforce interface contracts without runtime overhead
+ * - Used in template constraints to catch errors early
+ * - Enable better compiler diagnostics than SFINAE
+ */
+
+namespace nuts {
+
+//==============================================================================
+// Integer Type Concepts
+//==============================================================================
+
+/// @brief Concept for 32-bit signed integers
+template <typename T>
+concept SignedInteger32 =
+    sizeof(std::remove_cvref_t<T>) == 4 && std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for 32-bit unsigned integers
+template <typename T>
+concept UnsignedInteger32 =
+    sizeof(std::remove_cvref_t<T>) == 4 && !std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for any 32-bit integer (signed or unsigned)
+template <typename T>
+concept Integer32 = sizeof(std::remove_cvref_t<T>) == 4 && std::is_integral_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for 64-bit signed integers
+template <typename T>
+concept SignedInteger64 =
+    sizeof(std::remove_cvref_t<T>) == 8 && std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for 64-bit unsigned integers
+template <typename T>
+concept UnsignedInteger64 =
+    sizeof(std::remove_cvref_t<T>) == 8 && !std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for any 64-bit integer (signed or unsigned)
+template <typename T>
+concept Integer64 = sizeof(std::remove_cvref_t<T>) == 8 && std::is_integral_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for 32 bit floating point
+template <typename T>
+concept FloatingPoint32 =
+    sizeof(std::remove_cvref_t<T>) == 4 && std::is_floating_point_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for 64 bit floating point
+template <typename T>
+concept FloatingPoint64 =
+    sizeof(std::remove_cvref_t<T>) == 8 && std::is_floating_point_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for any floating point type
+template <typename T>
+concept FloatingPoint = std::is_floating_point_v<std::remove_cvref_t<T>>;
+
+/// @brief Concept for any integral type
+template <typename T>
+concept Integer = std::is_integral_v<std::remove_cvref_t<T>>;
+
+namespace details {
+/**
+ * Checks if a type's pointer is convertible to a templated base type's pointer.
+ * If the arbitrary function
+ *
+ * std::true_type f(const Base<Derived>*) *
+ * is well formed for input `std::declval<Derived*>() this has a member
+ *  value equal to `true`, otherwise the value is false.
+ * @tparam Base The templated base type for valid pointer conversion.
+ * @tparam Derived The type to check
+ * @ingroup type_trait
+ */
+template <template <typename> class Base, typename Derived>
+struct is_base_pointer_convertible {
+  static std::false_type f(const void *);
+  template <typename OtherDerived>
+  static std::true_type f(const Base<OtherDerived> *);
+  enum {
+    value
+    = decltype(f(std::declval<std::remove_reference_t<Derived> *>()))::value
+  };
+};
+}
+
+template <template <class...> class Base, typename Derived>
+struct is_base_pointer_convertible : std::bool_constant<details::is_base_pointer_convertible<Base, Derived>::value> {};
+
+template <template <class...> class Base, typename Derived>
+inline bool constexpr is_base_pointer_convertible_v = is_base_pointer_convertible<Base, Derived>::value;
+
+// “Any Eigen expression” (dense or sparse): derived from EigenBase
+template <typename T>
+concept EigenAny
+    = is_base_pointer_convertible_v<Eigen::EigenBase, std::decay_t<T>>;
+
+// Dense matrix/vector expressions (excludes ArrayBase): derived from MatrixBase
+template <typename T>
+concept EigenMatrixBase = is_base_pointer_convertible_v<Eigen::MatrixBase, std::decay_t<T>>;
+
+// Dense objects including arrays: derived from DenseBase
+template <typename T>
+concept EigenDenseBase = is_base_pointer_convertible_v<Eigen::DenseBase, std::decay_t<T>>;
+
+// 1D (vector) vs 2D (matrix) using Eigen compile-time shape
+template <typename T>
+concept EigenVector
+    = EigenMatrixBase<T>
+      && ((std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1) ||
+          (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1));
+
+template <typename T>
+concept EigenColVector
+    = EigenMatrixBase<T> && (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1);
+
+template <typename T>
+concept EigenRowVector
+    = EigenMatrixBase<T> && (std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1);
+
+template <typename T>
+concept EigenMatrix
+    = EigenMatrixBase<T>
+      && (std::decay_t<T>::RowsAtCompileTime != 1 && std::decay_t<T>::ColsAtCompileTime != 1);
+
+// Concept for a log density/gradient function
+template <typename F, typename Arg1, typename Arg2, typename Arg3>
+concept LogDensityGradientFunction = EigenVector<Arg1> && FloatingPoint<Arg2> && EigenVector<Arg3> &&
+  requires(F&& f, Arg1&& a1, Arg2&& a2, Arg3&& a3) {
+    { std::forward<F>(f)(std::forward<Arg1>(a1), std::forward<Arg2>(a2), std::forward<Arg3>(a3)) } -> std::same_as<void>;
+};
+
+template <typename F, typename S>
+concept LogGradFun = FloatingPoint<S> && LogDensityGradientFunction<F, Eigen::Matrix<S, -1, 1>&, S&, Eigen::Matrix<S, -1, 1>&>;
+
+
+}  // namespace nuts

--- a/include/walnuts/concepts.hpp
+++ b/include/walnuts/concepts.hpp
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <limits>
 #include <type_traits>
-#include <Eigen/Dense>
 /**
  * @file concepts.hpp
  * @brief C++20 concepts for compile-time interface checking
@@ -30,41 +29,47 @@ namespace nuts {
 
 /// @brief Concept for 32-bit signed integers
 template <typename T>
-concept SignedInteger32 =
-    sizeof(std::remove_cvref_t<T>) == 4 && std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+concept SignedInteger32 = sizeof(std::remove_cvref_t<T>) == 4 &&
+                          std::is_signed_v<std::remove_cvref_t<T>> &&
+                          std::is_integral_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for 32-bit unsigned integers
 template <typename T>
-concept UnsignedInteger32 =
-    sizeof(std::remove_cvref_t<T>) == 4 && !std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+concept UnsignedInteger32 = sizeof(std::remove_cvref_t<T>) == 4 &&
+                            !std::is_signed_v<std::remove_cvref_t<T>> &&
+                            std::is_integral_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for any 32-bit integer (signed or unsigned)
 template <typename T>
-concept Integer32 = sizeof(std::remove_cvref_t<T>) == 4 && std::is_integral_v<std::remove_cvref_t<T>>;
+concept Integer32 = sizeof(std::remove_cvref_t<T>) == 4 &&
+                    std::is_integral_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for 64-bit signed integers
 template <typename T>
-concept SignedInteger64 =
-    sizeof(std::remove_cvref_t<T>) == 8 && std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+concept SignedInteger64 = sizeof(std::remove_cvref_t<T>) == 8 &&
+                          std::is_signed_v<std::remove_cvref_t<T>> &&
+                          std::is_integral_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for 64-bit unsigned integers
 template <typename T>
-concept UnsignedInteger64 =
-    sizeof(std::remove_cvref_t<T>) == 8 && !std::is_signed_v<std::remove_cvref_t<T>> && std::is_integral_v<std::remove_cvref_t<T>>;
+concept UnsignedInteger64 = sizeof(std::remove_cvref_t<T>) == 8 &&
+                            !std::is_signed_v<std::remove_cvref_t<T>> &&
+                            std::is_integral_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for any 64-bit integer (signed or unsigned)
 template <typename T>
-concept Integer64 = sizeof(std::remove_cvref_t<T>) == 8 && std::is_integral_v<std::remove_cvref_t<T>>;
+concept Integer64 = sizeof(std::remove_cvref_t<T>) == 8 &&
+                    std::is_integral_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for 32 bit floating point
 template <typename T>
-concept FloatingPoint32 =
-    sizeof(std::remove_cvref_t<T>) == 4 && std::is_floating_point_v<std::remove_cvref_t<T>>;
+concept FloatingPoint32 = sizeof(std::remove_cvref_t<T>) == 4 &&
+                          std::is_floating_point_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for 64 bit floating point
 template <typename T>
-concept FloatingPoint64 =
-    sizeof(std::remove_cvref_t<T>) == 8 && std::is_floating_point_v<std::remove_cvref_t<T>>;
+concept FloatingPoint64 = sizeof(std::remove_cvref_t<T>) == 8 &&
+                          std::is_floating_point_v<std::remove_cvref_t<T>>;
 
 /// @brief Concept for any floating point type
 template <typename T>
@@ -88,67 +93,80 @@ namespace details {
  */
 template <template <typename> class Base, typename Derived>
 struct is_base_pointer_convertible {
-  static std::false_type f(const void *);
+  static std::false_type f(const void*);
   template <typename OtherDerived>
-  static std::true_type f(const Base<OtherDerived> *);
+  static std::true_type f(const Base<OtherDerived>*);
   enum {
-    value
-    = decltype(f(std::declval<std::remove_reference_t<Derived> *>()))::value
+    value =
+        decltype(f(std::declval<std::remove_reference_t<Derived>*>()))::value
   };
 };
-}
+}  // namespace details
 
 template <template <class...> class Base, typename Derived>
-struct is_base_pointer_convertible : std::bool_constant<details::is_base_pointer_convertible<Base, Derived>::value> {};
+struct is_base_pointer_convertible
+    : std::bool_constant<
+          details::is_base_pointer_convertible<Base, Derived>::value> {};
 
 template <template <class...> class Base, typename Derived>
-inline bool constexpr is_base_pointer_convertible_v = is_base_pointer_convertible<Base, Derived>::value;
+inline bool constexpr is_base_pointer_convertible_v =
+    is_base_pointer_convertible<Base, Derived>::value;
 
 // “Any Eigen expression” (dense or sparse): derived from EigenBase
 template <typename T>
-concept EigenAny
-    = is_base_pointer_convertible_v<Eigen::EigenBase, std::decay_t<T>>;
+concept EigenAny =
+    is_base_pointer_convertible_v<Eigen::EigenBase, std::decay_t<T>>;
 
 // Dense matrix/vector expressions (excludes ArrayBase): derived from MatrixBase
 template <typename T>
-concept EigenMatrixBase = is_base_pointer_convertible_v<Eigen::MatrixBase, std::decay_t<T>>;
+concept EigenMatrixBase =
+    is_base_pointer_convertible_v<Eigen::MatrixBase, std::decay_t<T>>;
 
 // Dense objects including arrays: derived from DenseBase
 template <typename T>
-concept EigenDenseBase = is_base_pointer_convertible_v<Eigen::DenseBase, std::decay_t<T>>;
+concept EigenDenseBase =
+    is_base_pointer_convertible_v<Eigen::DenseBase, std::decay_t<T>>;
 
 // 1D (vector) using Eigen compile-time shape
 template <typename T>
-concept EigenVector
-    = EigenMatrixBase<T>
-      && ((std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1) ||
-          (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1));
+concept EigenVector =
+    EigenMatrixBase<T> && ((std::decay_t<T>::RowsAtCompileTime == 1 &&
+                            std::decay_t<T>::ColsAtCompileTime != 1) ||
+                           (std::decay_t<T>::ColsAtCompileTime == 1 &&
+                            std::decay_t<T>::RowsAtCompileTime != 1));
 
 // Concept for a 1D column vector
 template <typename T>
-concept EigenColVector
-    = EigenVector<T> && (std::decay_t<T>::ColsAtCompileTime == 1 && std::decay_t<T>::RowsAtCompileTime != 1);
+concept EigenColVector =
+    EigenVector<T> && (std::decay_t<T>::ColsAtCompileTime == 1 &&
+                       std::decay_t<T>::RowsAtCompileTime != 1);
 
 // Concept for a 1d row vector
 template <typename T>
-concept EigenRowVector
-    = EigenVector<T> && (std::decay_t<T>::RowsAtCompileTime == 1 && std::decay_t<T>::ColsAtCompileTime != 1);
+concept EigenRowVector =
+    EigenVector<T> && (std::decay_t<T>::RowsAtCompileTime == 1 &&
+                       std::decay_t<T>::ColsAtCompileTime != 1);
 
 // A 2d matrix
 template <typename T>
-concept EigenMatrix
-    = EigenMatrixBase<T>
-      && (std::decay_t<T>::RowsAtCompileTime != 1 && std::decay_t<T>::ColsAtCompileTime != 1);
+concept EigenMatrix =
+    EigenMatrixBase<T> && (std::decay_t<T>::RowsAtCompileTime != 1 &&
+                           std::decay_t<T>::ColsAtCompileTime != 1);
 
 // Concept for a log density/gradient function
 template <typename F, typename Arg1, typename Arg2, typename Arg3>
-concept LogDensityGradientFunction = EigenVector<Arg1> && FloatingPoint<Arg2> && EigenVector<Arg3> &&
-  requires(F&& f, Arg1&& a1, Arg2&& a2, Arg3&& a3) {
-    { std::forward<F>(f)(std::forward<Arg1>(a1), std::forward<Arg2>(a2), std::forward<Arg3>(a3)) } -> std::same_as<void>;
-};
+concept LogDensityGradientFunction =
+    EigenVector<Arg1> && FloatingPoint<Arg2> && EigenVector<Arg3> &&
+    requires(F&& f, Arg1&& a1, Arg2&& a2, Arg3&& a3) {
+      {
+        std::forward<F>(f)(std::forward<Arg1>(a1), std::forward<Arg2>(a2),
+                           std::forward<Arg3>(a3))
+      } -> std::same_as<void>;
+    };
 
 template <typename F, typename S>
-concept LogGradFun = FloatingPoint<S> && LogDensityGradientFunction<F, Eigen::Matrix<S, -1, 1>&, S&, Eigen::Matrix<S, -1, 1>&>;
-
+concept LogGradFun = FloatingPoint<S> &&
+                     LogDensityGradientFunction<F, Eigen::Matrix<S, -1, 1>&, S&,
+                                                Eigen::Matrix<S, -1, 1>&>;
 
 }  // namespace nuts

--- a/include/walnuts/padded.hpp
+++ b/include/walnuts/padded.hpp
@@ -6,7 +6,7 @@
 #include <cstddef>
 #include <new>
 
-namespace walnuts {
+namespace nuts {
 
 /**
  * @brief The destructive interference size, if non-zero, else 128.
@@ -42,4 +42,4 @@ struct alignas(Align) Padded {
   std::array<std::byte, PADDING_BYTES> pad_{};
 };
 
-}  // namespace walnuts
+}  // namespace nuts

--- a/include/walnuts/triple_buffer.hpp
+++ b/include/walnuts/triple_buffer.hpp
@@ -9,7 +9,7 @@
 
 #include "walnuts/padded.hpp"
 
-namespace walnuts {
+namespace nuts {
 
 /*
  * @brief A lock-free, single-producer, single-consumer queue with triple buffering.
@@ -50,7 +50,7 @@ class TripleBuffer {
       back_(other.back_),
       read_(other.read_) {}
 
-  
+
   /**
    * Move the specified buffer into this buffer.
    *
@@ -67,7 +67,7 @@ class TripleBuffer {
     read_ = other.read_;
     return *this;
   }
-  
+
   TripleBuffer(const TripleBuffer&) = delete;
   TripleBuffer& operator=(const TripleBuffer&) = delete;
 
@@ -79,7 +79,7 @@ class TripleBuffer {
   T& write_buffer() noexcept { return buffers_[back_]; }
 
   /**
-   * Commit the changes to the write buffer. 
+   * Commit the changes to the write buffer.
    */
   void publish() noexcept {
     const int published = back_;
@@ -122,4 +122,4 @@ class TripleBuffer {
   index_t read_;
 };
 
-}  // namespace walnuts  
+}  // namespace nuts

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -5,7 +5,8 @@
 #include <utility>
 
 #include <Eigen/Dense>
-
+#include <walnuts/concepts.hpp>
+#include <walnuts/attributes.hpp>
 #include "util.hpp"
 
 namespace nuts {
@@ -23,7 +24,7 @@ namespace nuts {
  *
  * @tparam S Type of scalars.
  */
-template <typename S>
+template <FloatingPoint S>
 class SpanW {
  public:
   /**
@@ -35,18 +36,19 @@ class SpanW {
    * @param[in] grad_theta The gradient of the log density at `theta`.
    * @param[in] logp The joint log density of the position and momentum.
    */
-  static SpanW<S> from_initial_point(Vec<S>&& theta, Vec<S>&& rho,
-                                     Vec<S>&& grad_theta, S logp) {
+  template <EigenVector Theta, EigenVector Rho, EigenVector ThetaGrad>
+  static SpanW<S> from_initial_point(Theta&& theta, Rho&& rho,
+                                     ThetaGrad&& grad_theta, S logp) {
     return {theta,
             rho,
             grad_theta,
             logp,
             theta,
-            std::move(rho),
+            std::forward<Rho>(rho),
             grad_theta,
             logp,
-            std::move(theta),
-            std::move(grad_theta),
+            std::forward<Theta>(theta),
+            std::forward<ThetaGrad>(grad_theta),
             logp};
   }
 
@@ -127,7 +129,7 @@ class SpanW {
  * @param[in,out] rho_next Input initial momentum, set to final position.
  * @param[in,out] grad_next Input initial gradient, set to final gradient.
  */
-template <typename S, typename F>
+template <FloatingPoint S, std::invocable<Vec<S>&, S&, Vec<S>&> F>
 bool within_tolerance(const F& logp_grad, const Vec<S>& inv_mass, S step,
                       std::size_t num_steps, S max_error, S logp_next,
                       Vec<S>& theta_next, Vec<S>& rho_next, Vec<S>& grad_next) {
@@ -162,7 +164,7 @@ bool within_tolerance(const F& logp_grad, const Vec<S>& inv_mass, S step,
  * @param[in] grad The final gradient from which to reverse.
  * @return `true` if the path ending in the specified state is reversible.
  */
-template <typename S, typename F>
+template <FloatingPoint S, LogGradFun<S> F>
 bool reversible(const F& logp_grad, const Vec<S>& inv_mass, S step,
                 std::size_t num_steps, std::size_t min_micro_steps, S max_error,
                 S logp_next, const Vec<S>& theta, const Vec<S>& rho,
@@ -212,7 +214,7 @@ bool reversible(const F& logp_grad, const Vec<S>& inv_mass, S step,
  * @param[in,out] adapt_handler The step-size adaptation handler.
  * @return `true` if the Hamiltonian is conserved reversibly.
  */
-template <Direction D, typename S, typename F, class A>
+template <Direction D, FloatingPoint S, LogGradFun<S> F, class A>
 bool macro_step(const F& logp_grad, const Vec<S>& inv_mass, S step,
                 std::size_t max_step_halvings, std::size_t min_micro_steps,
                 S max_error, const SpanW<S>& span, Vec<S>& theta_next,
@@ -272,7 +274,7 @@ bool macro_step(const F& logp_grad, const Vec<S>& inv_mass, S step,
  * @param span_new The span continuing the old span forward or backward in time.
  * @return The combined span.
  */
-template <Update U, Direction D, typename S, class Rand>
+template <Update U, Direction D, FloatingPoint S, class Rand>
 SpanW<S> combine(Rand& rng, SpanW<S>&& span_old, SpanW<S>&& span_new) {
   using std::log;
   S logp_total = log_sum_exp(span_old.logp_, span_new.logp_);
@@ -324,7 +326,7 @@ SpanW<S> combine(Rand& rng, SpanW<S>&& span_old, SpanW<S>&& span_new) {
  * @return The span resulting from extending the specified span or
  * `std::nullopt` if that could not be done reversibly within threshold.
  */
-template <Direction D, typename S, class F, class A>
+template <Direction D, FloatingPoint S, LogGradFun<S> F, class A>
 std::optional<SpanW<S>> build_leaf(const F& logp_grad, const SpanW<S>& span,
                                    const Vec<S>& inv_mass, S step,
                                    std::size_t max_step_halvings,
@@ -365,7 +367,7 @@ std::optional<SpanW<S>> build_leaf(const F& logp_grad, const SpanW<S>& span,
  * @param[in,out] adapt_handler The step-size adaptation handler.
  * @return The new span or `std::nullopt` if it could not be constructed.
  */
-template <Direction D, typename S, class F, class Rand, class A>
+template <Direction D, FloatingPoint S, LogGradFun<S> F, class Rand, class A>
 std::optional<SpanW<S>> build_span(Rand& rng, const F& logp_grad,
                                    const Vec<S>& inv_mass, S step,
                                    std::size_t depth,
@@ -420,7 +422,7 @@ std::optional<SpanW<S>> build_span(Rand& rng, const F& logp_grad,
  * @param[in,out] adapt_handler The step-size adaptation handler.
  * @return The next position in the Markov chain.
  */
-template <typename S, class F, class Rand, class A>
+template <FloatingPoint S, LogGradFun<S> F, class Rand, class A>
 Vec<S> transition_w(Rand& rand, const F& logp_grad, const Vec<S>& inv_mass,
                     const Vec<S>& chol_mass, S step, std::size_t max_depth,
                     std::size_t max_step_halvings, std::size_t min_micro_steps,
@@ -477,7 +479,7 @@ class NoOpHandler {
    * @tparam T The type of the functor argument.
    */
   template <typename T>
-  inline void operator()(const T&) const noexcept {}
+  WALNUTS_ALWAYS_INLINE_ constexpr void operator()(const T&) const noexcept {}
 };
 
 /**
@@ -505,13 +507,14 @@ class NoOpHandler {
  * @tparam S The type of scalars.
  * @tparam RNG The type of the base random number generator.
  */
-template <class F, typename S, class RNG>
+template <FloatingPoint S, LogGradFun<S> F, class RNG>
 class WalnutsSampler {
  public:
   /**
    * @brief Construct a WALNUTS sampler from the specified RNG, target log
    * density/gradient initialization, and tuning parameters.
    *
+   * @tparam FF A callable that is the same type as `F`.
    * @param[in] rand The randomizer for HMC.
    * @param[in] logp_grad The target log density and gradient function (see the
    * class documentation.
@@ -534,14 +537,15 @@ class WalnutsSampler {
    * @throw std::invalid_argument If `max_step_havlings` is not positive.
    * @throw std::invalid_argument If `min_micro_steps` is not positive.
    * @throw std::invalid_argument If `max_error` is not positive or not finite.
-
    */
-  WalnutsSampler(Random<S, RNG>& rand, const F& logp_grad, const Vec<S>& theta,
+  template <LogGradFun<S> FF>
+  requires(std::same_as<std::decay_t<FF>, std::decay_t<F>>)
+  WalnutsSampler(Random<S, RNG>& rand, FF&& logp_grad, const Vec<S>& theta,
                  const Vec<S>& inv_mass, S macro_step_size,
                  std::size_t max_nuts_depth, std::size_t max_step_halvings,
                  std::size_t min_micro_steps, S max_error)
       : rand_(rand),
-        logp_grad_(logp_grad),
+        logp_grad_(std::forward<FF>(logp_grad)),
         theta_(theta),
         inv_mass_(inv_mass),
         cholesky_mass_(inv_mass.array().sqrt().inverse().matrix()),
@@ -629,5 +633,13 @@ class WalnutsSampler {
   /** A handler for adaptation which does nothing. */
   const NoOpHandler no_op_adapt_handler_;
 };
+
+// CTAD guide
+template <FloatingPoint S, LogGradFun<S> FF, class RNG>
+WalnutsSampler(Random<S, RNG>& rand, FF&& logp_grad, const Vec<S>& theta,
+               const Vec<S>& inv_mass, S macro_step_size,
+               std::size_t max_nuts_depth, std::size_t max_step_halvings,
+               std::size_t min_micro_steps, S max_error) -> WalnutsSampler<S, std::decay_t<FF>, RNG>;
+
 
 }  // namespace nuts


### PR DESCRIPTION
## Summary

This adds a `concepts.hpp` and a `attributes.hpp` and sprinkles concepts around the library.

Concepts are defined for standard integral and floating point types, Eigen matrices, and the callable we use for calculating the gradient.

There were also two files that used the `walnuts` namespace instead of the `nuts` namespace so I changed those to put them in the `nuts` namespace.

