### PR TITLE
Triple buffer

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,4 +1,4 @@
-@article{betancourt2017conceptual,
+(2@article{betancourt2017conceptual,
   title={A conceptual introduction to {H}amiltonian {M}onte {C}arlo},
   author={Betancourt, Michael},
   journal={arXiv},
@@ -61,14 +61,6 @@
   year={2013},
   edition={Third},
   publisher={CRC Press}
-}
-
-@misc{guan2025triplebuffer,
-  title={Triple Buffer: Lock-free Concurrency Primitive},
-  author = {Guan, Ng Song},
-  year={2025},
-  url={https://medium.com/@sgn00/triple-buffer-lock-free-concurrency-primitive-611848627a1e},
-  howpublished={Medium}
 }
 
 @article{hird2025quantifying,

--- a/include/walnuts.hpp
+++ b/include/walnuts.hpp
@@ -9,8 +9,8 @@
 #include <walnuts/handlers.hpp>
 #include <walnuts/online_moments.hpp>
 #include <walnuts/sampler.hpp>
-#include <walnuts/summary.hpp>
 #include <walnuts/spsc_buffer.hpp>
+#include <walnuts/summary.hpp>
 #include <walnuts/util.hpp>
 #include <walnuts/validate.hpp>
 #include <walnuts/walnuts.hpp>

--- a/include/walnuts/adam.hpp
+++ b/include/walnuts/adam.hpp
@@ -2,8 +2,7 @@
 
 #include <cmath>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * The Adam stochastic gradient optimizer specialized for step-size
@@ -102,5 +101,4 @@ class Adam {
   const double learn_rate_decay_;
 };
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail

--- a/include/walnuts/adam.hpp
+++ b/include/walnuts/adam.hpp
@@ -18,11 +18,11 @@ namespace detail {
  * This implementation includes a learning rate schedule that divides
  * the specified learning rate by `pow(t, learn_rate_decay)` in
  * iteration `t` (indexed from 1).  The standard version of Adam
- * (2014; \cite kingma2014adam) uses `learn_decay_rate = 0`, so that
+ * (2014; @cite kingma2014adam) uses `learn_decay_rate = 0`, so that
  * the learning rate stays fixed and estimates continue to bounce
  * around with new observations. With stepsize decay, Adam converges
  * as long as `0 < learn_rate_decay <= 1`; see Zou et al.
- * (2019 \cite zou2019sufficient).  Nuts used `learn_rate_decay = 0.75` for dual
+ * (2019 @cite zou2019sufficient).  Nuts used `learn_rate_decay = 0.75` for dual
  * averaging and we have found `learn_rate_decay=0.5` to work well for
  * Adam.
  */

--- a/include/walnuts/adam.hpp
+++ b/include/walnuts/adam.hpp
@@ -8,22 +8,26 @@ namespace walnuts::detail {
  * The Adam stochastic gradient optimizer specialized for step-size
  * adaptation with a decreasing learning rate schedule.
  *
- * The specialization for step size builds in quadratic error,
- * following Nuts. That is, for observed accept rate `accept_observed`
- * and target accept rate `accept_target`, the error is `-0.5 *
- * (accept_observed - accept_target)^2` and its gradient is
+ * The specialization for step size builds in quadratic error (i.e.,
+ * log normal), following Nuts. That is, for observed accept rate
+ * `accept_observed` and target accept rate `accept_target`, the error
+ * is `-0.5 * (accept_observed - accept_target)^2` and its gradient is
  * `accept_target - accept_observed`.
  *
  * This implementation includes a learning rate schedule that divides
  * the specified learning rate by `pow(t, learn_rate_decay)` in
- * iteration `t` (indexed from 1).  The standard version of Adam
- * (2014; @cite kingma2014adam) uses `learn_decay_rate = 0`, so that
- * the learning rate stays fixed and estimates continue to bounce
- * around with new observations. With stepsize decay, Adam converges
- * as long as `0 < learn_rate_decay <= 1`; see Zou et al.
- * (2019 @cite zou2019sufficient).  Nuts used `learn_rate_decay = 0.75` for dual
- * averaging and we have found `learn_rate_decay=0.5` to work well for
- * Adam.
+ * iteration `t` (indexed from 1).  The standard version of Adam uses
+ * `learn_decay_rate = 0`, so that the learning rate stays fixed and
+ * estimates continue to bounce around with new observations. With
+ * stepsize decay, Adam converges as long as `0 < learn_rate_decay <=
+ * 1`; Nuts used `learn_rate_decay = 0.75` for dual averaging and
+ * `learn_rate_decay=0.5` is a reasonable default for Adam.
+ *
+ * @see Kingma and Ba (2014; @cite kingma2014adam) for the original
+ * Adam algorithm.
+ * 
+ * @see Zou et al. (2019 @cite zou2019sufficient) for the proof of
+ * convergence with step-size decay.
  */
 class Adam {
  public:

--- a/include/walnuts/adapt.hpp
+++ b/include/walnuts/adapt.hpp
@@ -17,8 +17,7 @@
 #include <walnuts/spsc_buffer.hpp>
 #include <walnuts/util.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief A struct to represent a snapshot of the adaptation process
@@ -62,43 +61,22 @@ struct alignas(FALSE_SHARING_GUARD_SIZE) AdaptSnapshot {
  */
 using Buffer = SpscBuffer<AdaptSnapshot>;
 
-// /**
-//  * @brief Return a buffer with the specified dimensionality.
-//  *
-//  * @param[in] dim The dimensionality of the positions.
-//  * @return A padded buffer of the specified dimensionality.
-//  */
-// inline Buffer construct_buffer(std::size_t dim) {
-//   auto snapshot = AdaptSnapshot(static_cast<Eigen::Index>(dim));
-//   return Buffer(snapshot);
-// }
-
-// /**
-//  * @brief Return a vector of buffers of the given sizes.
-//  *
-//  * @param[in] num_chains The number of Markov chains.
-//  * @param[in] dim The number of dimensions.
-//  * @return The buffer container.
-//  */
-// inline std::vector<Buffer> construct_buffers(std::size_t num_chains,
-//                                              std::size_t dim) {
-//   std::vector<Buffer> buffers;
-//   buffers.reserve(num_chains);
-//   for (std::size_t m = 0; m < num_chains; ++m) {
-//     buffers.emplace_back(construct_buffer(dim));
-//   }
-//   return buffers;
-// }
-
+/**
+ * @brief Return a deque of buffers of the given sizes.
+ *
+ * @param[in] num_chains The number of Markov chains.
+ * @param[in] dim The number of dimensions.
+ * @return The buffer container.
+ */
 inline std::deque<Buffer> construct_buffers(std::size_t num_chains,
-                                             std::size_t dim) {
+                                            std::size_t dim) {
   std::deque<Buffer> buffers;
   auto snapshot = AdaptSnapshot(static_cast<Eigen::Index>(dim));
   for (std::size_t m = 0; m < num_chains; ++m) {
     buffers.emplace_back(snapshot);
   }
   return buffers;
-}  
+}
 
 /**
  * @brief A class that encapsulates the work done in a Markov chain for
@@ -147,7 +125,7 @@ class AdaptWorker {
     start_gate_.get().arrive_and_wait();
     publish_snapshot(0);
     // from 1 so modulo ops don't trigger on first iteration
-    std::size_t iter = 1; 
+    std::size_t iter = 1;
     for (; iter <= warmup_config_.get().max_iter(); ++iter) {
       if (st.stop_requested()) {
         break;
@@ -298,5 +276,4 @@ inline void adapt(const InitConfig& init_cfg, const WarmupConfig& warmup_cfg,
   }
 }
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail

--- a/include/walnuts/adapt.hpp
+++ b/include/walnuts/adapt.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <deque>
 #include <functional>
 #include <latch>
 #include <limits>
@@ -61,33 +62,43 @@ struct alignas(FALSE_SHARING_GUARD_SIZE) AdaptSnapshot {
  */
 using Buffer = SpscBuffer<AdaptSnapshot>;
 
-/**
- * @brief Return a buffer with the specified dimensionality.
- *
- * @param[in] dim The dimensionality of the positions.
- * @return A padded buffer of the specified dimensionality.
- */
-inline Buffer construct_buffer(std::size_t dim) {
-  auto snapshot = AdaptSnapshot(static_cast<Eigen::Index>(dim));
-  return Buffer(snapshot);
-}
+// /**
+//  * @brief Return a buffer with the specified dimensionality.
+//  *
+//  * @param[in] dim The dimensionality of the positions.
+//  * @return A padded buffer of the specified dimensionality.
+//  */
+// inline Buffer construct_buffer(std::size_t dim) {
+//   auto snapshot = AdaptSnapshot(static_cast<Eigen::Index>(dim));
+//   return Buffer(snapshot);
+// }
 
-/**
- * @brief Return a vector of buffers of the given sizes.
- *
- * @param[in] num_chains The number of Markov chains.
- * @param[in] dim The number of dimensions.
- * @return The buffer container.
- */
-inline std::vector<Buffer> construct_buffers(std::size_t num_chains,
+// /**
+//  * @brief Return a vector of buffers of the given sizes.
+//  *
+//  * @param[in] num_chains The number of Markov chains.
+//  * @param[in] dim The number of dimensions.
+//  * @return The buffer container.
+//  */
+// inline std::vector<Buffer> construct_buffers(std::size_t num_chains,
+//                                              std::size_t dim) {
+//   std::vector<Buffer> buffers;
+//   buffers.reserve(num_chains);
+//   for (std::size_t m = 0; m < num_chains; ++m) {
+//     buffers.emplace_back(construct_buffer(dim));
+//   }
+//   return buffers;
+// }
+
+inline std::deque<Buffer> construct_buffers(std::size_t num_chains,
                                              std::size_t dim) {
-  std::vector<Buffer> buffers;
-  buffers.reserve(num_chains);
+  std::deque<Buffer> buffers;
+  auto snapshot = AdaptSnapshot(static_cast<Eigen::Index>(dim));
   for (std::size_t m = 0; m < num_chains; ++m) {
-    buffers.emplace_back(construct_buffer(dim));
+    buffers.emplace_back(snapshot);
   }
   return buffers;
-}
+}  
 
 /**
  * @brief A class that encapsulates the work done in a Markov chain for
@@ -135,8 +146,8 @@ class AdaptWorker {
     interactive_qos();  // Apple silicon top priority; o.w. no-op
     start_gate_.get().arrive_and_wait();
     publish_snapshot(0);
-    std::size_t iter = 1;  // from 1 so modulo ops don't rstart at 1 so % ops
-                           // don't trigger on first iteration
+    // from 1 so modulo ops don't trigger on first iteration
+    std::size_t iter = 1; 
     for (; iter <= warmup_config_.get().max_iter(); ++iter) {
       if (st.stop_requested()) {
         break;
@@ -198,7 +209,7 @@ struct AdaptResult {
  * @return Statistics for the completed adaptation process.
  */
 template <InterruptCallback IC>
-inline AdaptResult controller_loop(std::vector<Buffer>& buffers,
+inline AdaptResult controller_loop(std::deque<Buffer>& buffers,
                                    std::vector<AdaptSnapshot>& latest,
                                    const IC& interrupt_callback,
                                    const InitConfig& init_cfg,
@@ -261,7 +272,7 @@ inline AdaptResult controller_loop(std::vector<Buffer>& buffers,
 template <AdaptiveSampler A, InterruptCallback IC>
 inline void adapt(const InitConfig& init_cfg, const WarmupConfig& warmup_cfg,
                   std::vector<A>& adapters, const IC& interrupt_callback) {
-  std::vector<Buffer> buffers =
+  std::deque<Buffer> buffers =
       construct_buffers(init_cfg.num_chains(), init_cfg.dims());
   std::latch start_gate(static_cast<std::ptrdiff_t>(init_cfg.num_chains() + 1));
   std::vector<std::jthread> threads;

--- a/include/walnuts/adaptive_walnuts.hpp
+++ b/include/walnuts/adaptive_walnuts.hpp
@@ -18,8 +18,7 @@
 #include "walnuts/validate.hpp"
 #include "walnuts/walnuts.hpp"
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief A mass matrix estimator based on exponentially discounted draws
@@ -166,8 +165,7 @@ class MinMicroStepsAdaptHandler {
   double count_;
 };
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail
 
 namespace walnuts {
 

--- a/include/walnuts/concepts.hpp
+++ b/include/walnuts/concepts.hpp
@@ -8,8 +8,7 @@
 
 #include <Eigen/Dense>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief Concept for a type with a `.size()` member function.
@@ -174,8 +173,7 @@ concept AdaptiveSampler = requires(A& a, const A& ca) {
   { ca.log_mass() } -> std::convertible_to<Eigen::VectorXd>;
 };
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail
 
 namespace walnuts {
 

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -166,9 +166,9 @@ class InitConfig {
    * called internally.  It only implements rvalue moves because that
    * is the only way it is called.
    *
-   * @param step_sizes The step sizes.
-   * @param positions The positions.
-   * @param masses The diagonals of the diagonal mass matrixes.
+   * @param[in] step_sizes The step sizes.
+   * @param[in] positions The positions.
+   * @param[in] masses The diagonals of the diagonal mass matrixes.
    */
   InitConfig(std::vector<double>&& step_sizes,
              std::vector<Eigen::VectorXd>&& positions,

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -332,7 +332,7 @@ class InitConfigBuilder {
   /**
    * @brief Initialize the masses using the Nutpie outer product strategy.
    *
-   * Following Nutpie (Seyboldt et al. 2026 \cite seyboldt2025nutpie),
+   * Following Nutpie (Seyboldt et al. 2026 @cite seyboldt2025nutpie),
    * the initialization uses a smoothed negative outer product of
    * gradients.  More specifically, it uses the square root of the
    * absolute value of the outer proudct of gradients linearly interpolated with

--- a/include/walnuts/handlers.hpp
+++ b/include/walnuts/handlers.hpp
@@ -15,9 +15,8 @@
 
 #include "walnuts/validate.hpp"
 
-namespace walnuts {
+namespace walnuts::detail {
 
-namespace detail {
 /**
  * @brief Internal flag with value `true` if C++ received `SIGINT`.
  */
@@ -54,8 +53,7 @@ static void write_vector(std::ostream& os, const Eigen::VectorXd& v) {
   os.write(data, size);
 }
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail
 
 namespace walnuts {
 

--- a/include/walnuts/handlers.hpp
+++ b/include/walnuts/handlers.hpp
@@ -29,8 +29,8 @@ extern "C" void handle_sigint(int) { interrupted = true; }
  *
  * @tparam T The type to which input is cast and written.
  * @tparam S The type of the input value.
- * @param out The output stream.
- * @param x The value that is written as type `T`.
+ * @param[in] out The output stream.
+ * @param[in] x The value that is written as type `T`.
  */
 template <typename T, typename S>
   requires std::convertible_to<S, T> && std::is_trivially_copyable_v<T>
@@ -84,7 +84,7 @@ class GlobalStore {
   /**
    * @brief Handle the R-hat value.
    *
-   * @param r_hat The R-hat value.
+   * @param[in] r_hat The R-hat value.
    */
   void on_r_hat(double r_hat) { r_hats_.push_back(r_hat); }
 
@@ -137,8 +137,8 @@ class ChainStore {
   /**
    * @brief Handle the warmup completion event.
    *
-   * @param step_size The step size.
-   * @param diag_inv_mass The diagonal inverse mass matrix.
+   * @param[in] step_size The step size.
+   * @param[in] diag_inv_mass The diagonal inverse mass matrix.
    */
   void on_warmup_complete(double step_size,
                           const Eigen::VectorXd& diag_inv_mass) {
@@ -149,8 +149,8 @@ class ChainStore {
   /**
    * @brief Handle a sampling event.
    *
-   * @param position The position.
-   * @param lp The log density.
+   * @param[in] position The position.
+   * @param[in] lp The log density.
    */
   void on_sample(const Eigen::VectorXd& position, double lp) {
     draws_.push_back(position);

--- a/include/walnuts/online_moments.hpp
+++ b/include/walnuts/online_moments.hpp
@@ -7,8 +7,7 @@
 
 #include <walnuts/validate.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief Accumulator for online mean and smaple variance calculations.
@@ -246,5 +245,4 @@ class OnlineMoments {
   Eigen::VectorXd sum_sq_dev_;
 };
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail

--- a/include/walnuts/sampler.hpp
+++ b/include/walnuts/sampler.hpp
@@ -20,8 +20,7 @@
 #include <walnuts/spsc_buffer.hpp>
 #include <walnuts/util.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief A struct to hold the within chain summary statistics for
@@ -93,9 +92,8 @@ class ChainWorker {
       }
       double lp = sampler_.get()();
       logp_stats_.observe(lp);
-      ChainStats chain_stats{logp_stats_.mean(),
-	  logp_stats_.sample_variance(),
-	  logp_stats_.count()};
+      ChainStats chain_stats{logp_stats_.mean(), logp_stats_.sample_variance(),
+                             logp_stats_.count()};
       buffer_.get().write_buffer() = chain_stats;
       buffer_.get().publish();
     }
@@ -131,7 +129,7 @@ static void controller_loop(
     std::vector<SpscBuffer<ChainStats>>& stats_by_chain, GH& global_handler,
     const IC& interrupt_callback, double rhat_threshold, std::latch& start_gate,
     std::size_t min_draws_per_chain, std::size_t max_draws_per_chain,
-    std::chrono::milliseconds eval_period = std::chrono::milliseconds{10}) {
+    std::chrono::nanoseconds eval_period = std::chrono::milliseconds{1}) {
   interactive_qos();  // Apple silicon highest priority; o.w. no-op
   const std::size_t M = stats_by_chain.size();
   Eigen::VectorXd chain_means(M);
@@ -203,7 +201,7 @@ inline void sample(std::vector<S>& samplers, GH& global_handler,
   try {
     controller_loop(stats_by_chain, global_handler, interrupt_callback,
                     rhat_threshold, start_gate, min_draws_per_chain,
-                    max_draws_per_chain);
+                    max_draws_per_chain, std::chrono::milliseconds{1});
   } catch (const std::exception& e) {
     for (auto& t : threads) {
       t.request_stop();
@@ -212,5 +210,4 @@ inline void sample(std::vector<S>& samplers, GH& global_handler,
   }
 }
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail

--- a/include/walnuts/sampler.hpp
+++ b/include/walnuts/sampler.hpp
@@ -33,13 +33,13 @@ namespace detail {
  */
 struct ChainStats {
   /** The within-chain mean. */
-  float sample_mean;
+  double sample_mean;
 
   /** The within-chain variance. */
-  float sample_var;
+  double sample_var;
 
   /** The chain length. */
-  std::uint32_t count;
+  std::size_t count;
 };
 
 /**
@@ -93,9 +93,9 @@ class ChainWorker {
       }
       double lp = sampler_.get()();
       logp_stats_.observe(lp);
-      ChainStats chain_stats{static_cast<float>(logp_stats_.mean()),
-                             static_cast<float>(logp_stats_.sample_variance()),
-                             static_cast<uint32_t>(logp_stats_.count())};
+      ChainStats chain_stats{logp_stats_.mean(),
+	  logp_stats_.sample_variance(),
+	  logp_stats_.count()};
       buffer_.get().write_buffer() = chain_stats;
       buffer_.get().publish();
     }
@@ -148,10 +148,8 @@ static void controller_loop(
       if (counts[m] < min_draws_per_chain) {
         achieved_min_draws = false;
       }
-      chain_means(static_cast<Eigen::Index>(m)) =
-          static_cast<double>(u.sample_mean);
-      chain_variances(static_cast<Eigen::Index>(m)) =
-          static_cast<double>(u.sample_var);
+      chain_means(static_cast<Eigen::Index>(m)) = u.sample_mean;
+      chain_variances(static_cast<Eigen::Index>(m)) = u.sample_var;
     }
     if (achieved_min_draws) {
       double variance_of_means = variance(chain_means);

--- a/include/walnuts/spsc_buffer.hpp
+++ b/include/walnuts/spsc_buffer.hpp
@@ -43,8 +43,8 @@ namespace walnuts::detail {
  *
  * @code
  * Foo v_to_write = ...;
- * Foo& v_buffer = buf.write_buffer();
- * v_buffer = v_to_write;
+ * Foo& v_buf = buf.write_buffer();
+ * v_buf = v_to_write;
  * buf.publish();
  * @endcode
  *

--- a/include/walnuts/spsc_buffer.hpp
+++ b/include/walnuts/spsc_buffer.hpp
@@ -12,92 +12,116 @@
 namespace walnuts {
 namespace detail {
 
-/**
- * @brief A mutex-protected single-producer, single-consumer buffer.
- *
- * @tparam T Type of object buffered.
- */
-template <class T>
-class alignas(FALSE_SHARING_GUARD_SIZE) SpscBuffer {
- public:
   /**
-   * Construct a buffer with the specified value.
+   * @brief A single-producer, single-consumer queue backed by a triple buffer.
    *
-   * @param[in] t Value to write.
-   */
-  explicit SpscBuffer(const T& t) : write_buf_(t), read_buf_(t) {}
+   * In this buffer, `read_latest()` will always return the latest
+   * version published.  The `write_buffer()` and `publish()` pair may
+   * overwrite the latest value so that not all values written will be
+   * read.
+   * 
+   * The core design is based on brilliantsugar (2024
+   * @cite brilliantsugar2024triplebuffer), How I learned to stop worrying
+   * and love juggling C++ atomics.
+   * 
+   * @tparam T Type of object buffered.
+   */  
+  template <typename T>
+  class SpscBuffer {
+  public:
 
+    /**
+     * @brief Construct a buffer filled with copies of the specified value.
+     *
+     * @param[in] t Value to write.
+     */
+    explicit SpscBuffer(const T& t) : buffers_{{t}, {t}, {t}} {}
 
-  /**
-   * @brief Construct a buffer with a default-constructed value.
-   */
-  SpscBuffer() : SpscBuffer(T()) {}
+    /**
+     * @brief Construct a buffer filled with default-constructed values.
+     */    
+    SpscBuffer() requires std::default_initializable<T> : SpscBuffer(T()) {}
 
-  /**
-   * @brief Construct a triple buffer by moving the other buffer.
-   *
-   * @parma[in] other Buffer to move.
-   */
-  SpscBuffer(SpscBuffer&& other) noexcept(
-      std::is_nothrow_move_constructible_v<T>)
-      : write_buf_(std::move(other.write_buf_)),
-        read_buf_(std::move(other.read_buf_)) {}
+    SpscBuffer(const SpscBuffer&) = delete;
+    SpscBuffer& operator=(const SpscBuffer&) = delete;
+    SpscBuffer(SpscBuffer&&) = delete;
+    SpscBuffer& operator=(SpscBuffer&&) = delete;
 
-  /**
-   * @brief Move the other buffer's contents into this buffer.
-   *
-   * @param other The buffer to move.
-   * @return A refernece to this buffer.
-   */
-  SpscBuffer& operator=(SpscBuffer&& other) noexcept(
-      std::is_nothrow_move_assignable_v<T>) {
-    if (this == &other) {
-      return *this;
+    /**
+     * @brief Return a reference to the latest value.
+     *
+     * @return A refernece to the lateest value.
+     */
+    const T& read_latest() noexcept {
+      std::uint32_t mid = middle_.load(std::memory_order_relaxed);
+      if (is_dirty(mid)) {
+	std::uint32_t prev = middle_.exchange(front_, std::memory_order_acq_rel);
+	front_ = index_of(prev);
+      }
+      return buffers_[front_].data;
     }
-    write_buf_ = std::move(other.write_buf_);
-    read_buf_ = std::move(other.read_buf_);
-    return *this;
-  }
 
-  SpscBuffer(const SpscBuffer&) = delete;
-  SpscBuffer& operator=(const SpscBuffer&) = delete;
+    /**
+     * @brief Return a reference to a value into which to write.
+     *
+     * After a value is written into the return, the `publish()` method must
+     * be called to swap it in.
+     *
+     * @return Reference into which to write a value.
+     */
+    T& write_buffer() noexcept { return buffers_[back_].data; }
 
-  /**
-   * Return a reference into which the writer stages a value.
-   * Writer-only between publish() calls.
-   *
-   * @return The buffered value.
-   */
-  T& write_buffer() noexcept { return write_buf_; }
+    /**
+     * @brief Commit the latest state of the write buffer.
+     */
+    void publish() noexcept {
+      std::uint32_t prev = middle_.exchange(make_dirty(back_), std::memory_order_acq_rel);
+      back_ = index_of(prev);
+    }
 
-  /**
-   * Commit the staged value: copies write_buf_ into read_buf_ under the lock.
-   */
-  void publish() noexcept {
-    std::lock_guard<std::mutex> lock(mtx_);
-    read_buf_ = write_buf_;
-  }
+  private:
+    /** @brief Bit to mark an index as dirty */
+    static constexpr std::uint32_t DIRTY_BIT = 0x80000000u;  
 
-  /**
-   * Return a copy of the most recently published value.
-   *
-   * @return Most recently published value.
-   */
-  T read_latest() noexcept {
-    std::lock_guard<std::mutex> lock(mtx_);
-    return read_buf_;
-  }
+    /** @brief Mask to return the index. */
+    static constexpr std::uint32_t INDEX_MASK = ~DIRTY_BIT;
 
- private:
-  /** @brief Buffer for writing. */
-  T write_buf_;
+    /**
+     * @brief Return the dirty form of the index.
+     *
+     * @see index_of to recover the underlying index.
+     *
+     * @param[in] idx Index to make dirty.
+     * @return The dirty form of the index.
+     */
+    static std::uint32_t make_dirty(std::uint32_t idx) noexcept { return idx | DIRTY_BIT; }
 
-  /** @brief Mutex used to guard reading. */
-  alignas(FALSE_SHARING_GUARD_SIZE) std::mutex mtx_;
+    /** 
+     * @brief Return the clean form of the specified index.
+     *
+     * @param[in] A potentially dirty index.
+     * @return The index underlying the argument in {0, 1, 2}.
+     */
+    static std::uint32_t index_of(std::uint32_t idx) noexcept { return idx & INDEX_MASK; }
 
-  /** @brief Buffer for reading. */
-  T read_buf_;
-};
+    /**
+     * @brief Return true if the index is dirty.
+     *
+     * @param idx The index.
+     * @return `true` if the index is dirty.
+     */
+    static bool is_dirty(std::uint32_t idx) noexcept { return (idx & DIRTY_BIT) != 0; }
 
-}  // namespace detail
-}  // namespace walnuts
+    /**
+     * @brief A structure to hold an aligned form of the type `T`.
+     */
+    struct alignas(FALSE_SHARING_GUARD_SIZE) AlignedT { T data{}; };
+
+    AlignedT buffers_[3];
+    std::atomic<std::uint32_t> middle_{1};
+    alignas(FALSE_SHARING_GUARD_SIZE) std::uint32_t back_{0};
+    alignas(FALSE_SHARING_GUARD_SIZE) std::uint32_t front_{2};
+  };
+
+}
+}

--- a/include/walnuts/spsc_buffer.hpp
+++ b/include/walnuts/spsc_buffer.hpp
@@ -143,7 +143,7 @@ class SpscBuffer {
   /**
    * @brief Return true if the index is dirty.
    *
-   * @param idx The index.
+   * @param[in] idx The index.
    * @return `true` if the index is dirty.
    */
   static bool is_dirty(std::uint32_t idx) noexcept {

--- a/include/walnuts/spsc_buffer.hpp
+++ b/include/walnuts/spsc_buffer.hpp
@@ -9,119 +9,158 @@
 #include <walnuts/concepts.hpp>
 #include <walnuts/util.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
+
+/**
+ * @brief A single-producer, single-consumer buffer backed by a
+ * lock-free triple buffer.
+ *
+ * Initialization: The buffer is initialized with an initial
+ * value either explicitly or through the default constructor
+ * for the value type.
+ *
+ * @code
+ * Foo v_init;
+ * SpscBuffer<Foo> buf(v_init);
+ * @endcode
+ *
+ * Reading:  `read_latest()` will always return the latest
+ * value published.
+ *
+ * @code
+ * Foo v_latest = buf.read_latest();
+ * @endcode
+ *
+ * Writing: The following code writes a value into the buffer.
+ *
+ * @code
+ * Foo v_to_write = ...;
+ * Foo& v_buffer = buf.write_buffer();
+ * v_buffer = v_to_write;
+ * buf.publish();
+ * @endcode
+ *
+ * Unlike a queue pattern, `publish()` overwrites the current value
+ * even if the current value has never been read.
+ *
+ * Implementation note: The implementation uses bit twiddling,
+ * packing both a dirty bit indicator and the value 0, 1, or 2, into
+ * a single `uint32_t` in order to allow the swaps to be
+ * atomic. Helper functions are provided to read the dirty bit, add
+ * a dirty bit to an index, or return the index from a potentially
+ * dirty bit.
+ *
+ * See @cite brilliantsugar2024triplebuffer.
+ * brilliantsugar. 2024. How I learned to stop worrying and love
+ * juggling C++ atomics.
+ *
+ * @tparam T Type of value buffered.
+ */
+template <typename T>
+class SpscBuffer {
+ public:
+  /**
+   * @brief Construct a buffer filled with copies of the specified value.
+   *
+   * @param[in] t Value to write.
+   */
+  explicit SpscBuffer(const T& t) : buffers_{{t}, {t}, {t}} {}
 
   /**
-   * @brief A single-producer, single-consumer queue backed by a triple buffer.
+   * @brief Construct a buffer filled with default-constructed values.
+   */
+  SpscBuffer()
+    requires std::default_initializable<T>
+      : SpscBuffer(T()) {}
+
+  SpscBuffer(const SpscBuffer&) = delete;
+  SpscBuffer& operator=(const SpscBuffer&) = delete;
+  SpscBuffer(SpscBuffer&&) = delete;
+  SpscBuffer& operator=(SpscBuffer&&) = delete;
+
+  /**
+   * @brief Return a reference to the latest value.
    *
-   * In this buffer, `read_latest()` will always return the latest
-   * version published.  The `write_buffer()` and `publish()` pair may
-   * overwrite the latest value so that not all values written will be
-   * read.
-   * 
-   * The core design is based on brilliantsugar (2024
-   * @cite brilliantsugar2024triplebuffer), How I learned to stop worrying
-   * and love juggling C++ atomics.
-   * 
-   * @tparam T Type of object buffered.
-   */  
-  template <typename T>
-  class SpscBuffer {
-  public:
-
-    /**
-     * @brief Construct a buffer filled with copies of the specified value.
-     *
-     * @param[in] t Value to write.
-     */
-    explicit SpscBuffer(const T& t) : buffers_{{t}, {t}, {t}} {}
-
-    /**
-     * @brief Construct a buffer filled with default-constructed values.
-     */    
-    SpscBuffer() requires std::default_initializable<T> : SpscBuffer(T()) {}
-
-    SpscBuffer(const SpscBuffer&) = delete;
-    SpscBuffer& operator=(const SpscBuffer&) = delete;
-    SpscBuffer(SpscBuffer&&) = delete;
-    SpscBuffer& operator=(SpscBuffer&&) = delete;
-
-    /**
-     * @brief Return a reference to the latest value.
-     *
-     * @return A refernece to the lateest value.
-     */
-    const T& read_latest() noexcept {
-      std::uint32_t mid = middle_.load(std::memory_order_relaxed);
-      if (is_dirty(mid)) {
-	std::uint32_t prev = middle_.exchange(front_, std::memory_order_acq_rel);
-	front_ = index_of(prev);
-      }
-      return buffers_[front_].data;
+   * @return A refernece to the lateest value.
+   */
+  const T& read_latest() noexcept {
+    std::uint32_t mid = middle_.load(std::memory_order_relaxed);
+    if (is_dirty(mid)) {
+      std::uint32_t prev = middle_.exchange(front_, std::memory_order_acq_rel);
+      front_ = index_of(prev);
     }
+    return buffers_[front_].data;
+  }
 
-    /**
-     * @brief Return a reference to a value into which to write.
-     *
-     * After a value is written into the return, the `publish()` method must
-     * be called to swap it in.
-     *
-     * @return Reference into which to write a value.
-     */
-    T& write_buffer() noexcept { return buffers_[back_].data; }
+  /**
+   * @brief Return a reference to a value into which to write.
+   *
+   * After a value is written into the return, the `publish()` method must
+   * be called to swap it in.
+   *
+   * @return Reference into which to write a value.
+   */
+  T& write_buffer() noexcept { return buffers_[back_].data; }
 
-    /**
-     * @brief Commit the latest state of the write buffer.
-     */
-    void publish() noexcept {
-      std::uint32_t prev = middle_.exchange(make_dirty(back_), std::memory_order_acq_rel);
-      back_ = index_of(prev);
-    }
+  /**
+   * @brief Commit the latest state of the write buffer.
+   */
+  void publish() noexcept {
+    std::uint32_t prev =
+        middle_.exchange(make_dirty(back_), std::memory_order_acq_rel);
+    back_ = index_of(prev);
+  }
 
-  private:
-    /** @brief Bit to mark an index as dirty */
-    static constexpr std::uint32_t DIRTY_BIT = 0x80000000u;  
+ private:
+  /** @brief Bit to mark an index as dirty */
+  static constexpr std::uint32_t DIRTY_BIT = 0x80000000u;
 
-    /** @brief Mask to return the index. */
-    static constexpr std::uint32_t INDEX_MASK = ~DIRTY_BIT;
+  /** @brief Mask to return the index. */
+  static constexpr std::uint32_t INDEX_MASK = ~DIRTY_BIT;
 
-    /**
-     * @brief Return the dirty form of the index.
-     *
-     * @see index_of to recover the underlying index.
-     *
-     * @param[in] idx Index to make dirty.
-     * @return The dirty form of the index.
-     */
-    static std::uint32_t make_dirty(std::uint32_t idx) noexcept { return idx | DIRTY_BIT; }
+  /**
+   * @brief Return the index marked as dirty.
+   *
+   * @see index_of to recover the underlying index.
+   *
+   * @param[in] idx Index to make dirty.
+   * @return The dirty form of the index.
+   */
+  static std::uint32_t make_dirty(std::uint32_t idx) noexcept {
+    return idx | DIRTY_BIT;
+  }
 
-    /** 
-     * @brief Return the clean form of the specified index.
-     *
-     * @param[in] A potentially dirty index.
-     * @return The index underlying the argument in {0, 1, 2}.
-     */
-    static std::uint32_t index_of(std::uint32_t idx) noexcept { return idx & INDEX_MASK; }
+  /**
+   * @brief Return the clean form of the specified index.
+   *
+   * @param[in] idx A potentially dirty index.
+   * @return The index underlying the argument in {0, 1, 2}.
+   */
+  static std::uint32_t index_of(std::uint32_t idx) noexcept {
+    return idx & INDEX_MASK;
+  }
 
-    /**
-     * @brief Return true if the index is dirty.
-     *
-     * @param idx The index.
-     * @return `true` if the index is dirty.
-     */
-    static bool is_dirty(std::uint32_t idx) noexcept { return (idx & DIRTY_BIT) != 0; }
+  /**
+   * @brief Return true if the index is dirty.
+   *
+   * @param idx The index.
+   * @return `true` if the index is dirty.
+   */
+  static bool is_dirty(std::uint32_t idx) noexcept {
+    return (idx & DIRTY_BIT) != 0;
+  }
 
-    /**
-     * @brief A structure to hold an aligned form of the type `T`.
-     */
-    struct alignas(FALSE_SHARING_GUARD_SIZE) AlignedT { T data{}; };
-
-    AlignedT buffers_[3];
-    std::atomic<std::uint32_t> middle_{1};
-    alignas(FALSE_SHARING_GUARD_SIZE) std::uint32_t back_{0};
-    alignas(FALSE_SHARING_GUARD_SIZE) std::uint32_t front_{2};
+  /**
+   * @brief A structure to hold an aligned form of the type `T`.
+   */
+  struct alignas(FALSE_SHARING_GUARD_SIZE) AlignedT {
+    T data{};
   };
 
-}
-}
+  AlignedT buffers_[3];
+  std::atomic<std::uint32_t> middle_{1};
+  alignas(FALSE_SHARING_GUARD_SIZE) std::uint32_t back_{0};
+  alignas(FALSE_SHARING_GUARD_SIZE) std::uint32_t front_{2};
+};
+
+}  // namespace walnuts::detail

--- a/include/walnuts/spsc_buffer.hpp
+++ b/include/walnuts/spsc_buffer.hpp
@@ -17,21 +17,29 @@ namespace walnuts::detail {
  *
  * Initialization: The buffer is initialized with an initial
  * value either explicitly or through the default constructor
- * for the value type.
+ * for the value type and then made available to a single consumer
+ * and to a single producer.
+ *
+ * Warning: This class is not safe for use by more than one consumer
+ * or more than one producer.
  *
  * @code
  * Foo v_init;
  * SpscBuffer<Foo> buf(v_init);
  * @endcode
  *
- * Reading:  `read_latest()` will always return the latest
- * value published.
+ * Reading: `read_latest()` will always return the latest value
+ * published.
  *
  * @code
  * Foo v_latest = buf.read_latest();
  * @endcode
  *
- * Writing: The following code writes a value into the buffer.
+ * `read_latest()` is not generically thread safe and must only be
+ * called by the single consumer.
+ *
+ * Writing: The write code will only be used by a single producer.
+ * The following code writes a value into the buffer.
  *
  * @code
  * Foo v_to_write = ...;
@@ -39,6 +47,9 @@ namespace walnuts::detail {
  * v_buffer = v_to_write;
  * buf.publish();
  * @endcode
+ *
+ * `write_buffer()` and `publish()` are not generically thread safe
+ * and must only be called by the single producer.
  *
  * Unlike a queue pattern, `publish()` overwrites the current value
  * even if the current value has never been read.

--- a/include/walnuts/summary.hpp
+++ b/include/walnuts/summary.hpp
@@ -10,8 +10,7 @@
 
 #include <walnuts/concepts.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 template <typename Derived>
 inline Eigen::RowVectorXd col_means(const Eigen::MatrixBase<Derived>& draws) {
@@ -102,8 +101,7 @@ inline Eigen::RowVectorXd sample_variance(
   return sample_variance(draws, detail::col_means(draws));
 }
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail
 
 namespace walnuts {
 

--- a/include/walnuts/summary.hpp
+++ b/include/walnuts/summary.hpp
@@ -29,7 +29,7 @@ constexpr inline Eigen::Index strip_factor(Eigen::Index m,
  * @brief Return smallest number greater than or equal to
  * input that is evenly divisible by 2, 3, and 5.
  *
- * @param n Original size.
+ * @param[in] n Original size.
  * @return Original size padded for divisibility.
  */
 constexpr inline Eigen::Index fft_next_good_size(Eigen::Index n) {
@@ -181,7 +181,7 @@ class MarkovChainsSplit {
    * The return is an expression template that will hold a reference
    * to the chain managed by this class.
    *
-   * @param m The index of the chain.
+   * @param[in] m The index of the chain.
    * @return A view of the specified chain.
    * @throw std::out_of_range If the index is greater than or equal to
    * the number of chains.
@@ -209,7 +209,7 @@ class MarkovChainsSplit {
    * This implementation allocates a vector to return of the
    * appropriate size.
    *
-   * @param d The selected dimension.
+   * @param[in] d The selected dimension.
    * @return The draws for the selecte dimension.
    * @throws std::out_of_range If the index is not between 0 and
    * the number of dimensions minus 1, inclusive.
@@ -254,8 +254,8 @@ class MarkovChainsUnified {
    * The implementation holds a constant reference to the matrix of
    * draws so that the `draws` matrix must outlive this instance.
    *
-   * @param draws The sequence of Markov chains states, one row per draw.
-   * @param chain_sizes The sizes of the Markov chains making up the
+   * @param[in] draws The sequence of Markov chains states, one row per draw.
+   * @param[in] chain_sizes The sizes of the Markov chains making up the
    * collection.
    * @throw std::invalid_argument If the sum of the chain sizes
    * is not equal to the number of draws.
@@ -308,7 +308,7 @@ class MarkovChainsUnified {
    * The return is an expression template that will hold a reference
    * to the draws.
    *
-   * @param m The index of the chain.
+   * @param[in] m The index of the chain.
    * @return A view of the specified chain.
    * @throw std::out_of_range If the index is greater than or equal to
    * the number of chains.
@@ -335,7 +335,7 @@ class MarkovChainsUnified {
    * The return is an expression template for a constant vector that
    * depends on the draws.
    *
-   * @param d The selected dimension.
+   * @param[in] d The selected dimension.
    * @return The draws for the selecte dimension.
    * @throws std::out_of_range If the index is not between 0 and
    * the number of dimensions minus 1, inclusive.
@@ -364,7 +364,7 @@ static_assert(MarkovChainSequence<MarkovChainsUnified>);
  * dimension).
  *
  * @tparam MC The type of the Markov chain sequence.
- * @param chains The Markov chains.
+ * @param[in] chains The Markov chains.
  * @return The sample means.
  */
 template <MarkovChainSequence MC>
@@ -387,7 +387,7 @@ inline Eigen::RowVectorXd mean(const MC& chains) {
  * entire population, it will be biased to the high side.
  *
  * @tparam MC The type of the Markov chain sequence.
- * @param chains The Markov chains.
+ * @param[in] chains The Markov chains.
  * @return The variances.
  */
 template <MarkovChainSequence MC>
@@ -414,7 +414,7 @@ inline Eigen::RowVectorXd sample_variance(const MC& chains) {
  * deviations due to the nonlinearity of the square root operation.
  *
  * @tparam MC The type of the Markov chain sequence.
- * @param chains The Markov chains.
+ * @param[in] chains The Markov chains.
  * @return The standard deviations.
  */
 template <MarkovChainSequence MC>
@@ -734,7 +734,7 @@ inline Eigen::RowVectorXd effective_sample_size(const MC& chains) {
  * @see sample_standard_deviation()
  *
  * @tparam MC The type of the Markov chain sequence.
- * @param chains The Markov chains.
+ * @param[in] chains The Markov chains.
  * @return The Monte Carlo standard error estimates.
  */
 template <MarkovChainSequence MC>

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -11,8 +11,7 @@
 
 #include <walnuts/concepts.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 #if defined(__has_attribute) && __has_attribute(always_inline)
 #define WALNUTS_STRONG_INLINE [[gnu::always_inline]] inline
@@ -307,5 +306,4 @@ inline double variance(const Eigen::VectorXd& xs) noexcept {
          static_cast<double>((xs.size() - 1));
 }
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail

--- a/include/walnuts/validate.hpp
+++ b/include/walnuts/validate.hpp
@@ -11,8 +11,7 @@
 
 #include <walnuts/concepts.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief Validate that the specified stream is open.
@@ -303,5 +302,4 @@ inline void validate_probability_inclusive(T x, const std::string& name) {
   throw std::invalid_argument(msg);
 }
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -16,8 +16,7 @@
 #include <walnuts/util.hpp>
 #include <walnuts/validate.hpp>
 
-namespace walnuts {
-namespace detail {
+namespace walnuts::detail {
 
 /**
  * @brief A class for holding the minimal information in a Hamiltonian
@@ -585,8 +584,7 @@ class NoOpStepSizeAdapter {
   }
 };
 
-}  // namespace detail
-}  // namespace walnuts
+}  // namespace walnuts::detail
 
 namespace walnuts {
 

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -660,14 +660,14 @@ class WalnutsSampler {
   /**
    * @brief Construct a sampler by copying the specified sampler.
    *
-   * @param sampler Sampler to copy.
+   * @param[in] sampler Sampler to copy.
    */
   WalnutsSampler(const WalnutsSampler& sampler) = default;
 
   /**
    * @brief Construct a sampler by moving the specified sampler.
    *
-   * @param sampler Sampler to move.
+   * @param[in] sampler Sampler to move.
    */
   WalnutsSampler(WalnutsSampler&& sampler) = default;
 


### PR DESCRIPTION
This version of the triple buffer hasn't triggered any thread sanitizer warnings.  

The key difference from the last attempt is making the exchanges atomic.  See:

https://brilliantsugar.github.io/posts/how-i-learned-to-stop-worrying-and-love-juggling-c++-atomics

I cite the blog post in the doc.  I converted the style from pointers back to indexes, which avoids conversions.  The mask is now on a high bit, because the index values are 0, 1, or 2.