### PR TITLE
fixing unit tests in CI [WIP]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,14 @@ if(WALNUTS_BUILD_STAN)
 endif()
 
 #############################
+## Windows pathces         ##
+#############################
+
+if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_link_options(-static-libgcc -static-libstdc++ -static -lpthread)
+endif()
+
+#############################
 ## Making Walnuts Library  ##
 #############################
 

--- a/include/walnuts/summary.hpp
+++ b/include/walnuts/summary.hpp
@@ -56,7 +56,7 @@ inline void autocovariance_col(const Eigen::Ref<const Eigen::VectorXd>& y,
                                Eigen::VectorXcd& ac_tmp) {
   // TODO: evaluate the following optimization
   // fft.SetFlag(fft.HalfSpectrum);
-  Eigen::Index M2 = ac.size();
+  Eigen::Index M2 = padded_signal.size();
   Eigen::Index N = y.size();
   padded_signal.tail(M2 - N).setZero();
   padded_signal.head(N) = y.array() - y.mean();

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -40,6 +40,16 @@ static std::vector<double> inf_nan_neg_zero_leq_one() {
   return result;
 }
 
+template <int R, int C>
+static void expect_near(const Eigen::Matrix<double, R, C>& x,
+			const Eigen::Matrix<double, R, C>& y,
+			double tolerance = 1e-10) {
+  EXPECT_EQ(x.size(), y.size());
+  for (Eigen::Index n = 0; n < x.size(); ++n) {
+    EXPECT_NEAR(x(n), y(n), tolerance);
+  }
+}
+
 static void std_normal(const Eigen::VectorXd& x, double& lp,
                        Eigen::VectorXd& grad) {
   lp = -0.5 * x.dot(x);
@@ -182,7 +192,7 @@ TEST(InitConfigBuilder, ScalarPositionSetsAllChains) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(3, 2).positions(pos).build();
   for (std::size_t n = 0; n < 3; ++n) {
-    EXPECT_TRUE(cfg.position(n).isApprox(pos));
+    expect_near(cfg.position(n), pos);
   }
 }
 
@@ -212,7 +222,7 @@ TEST(InitConfigBuilder, VectorPositionsSetsPerChain) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(3, 2).positions(vs).build();
   for (std::size_t m = 0; m < 3; ++m) {
-    EXPECT_TRUE(cfg.position(m).isApprox(vs[m]));
+    expect_near(cfg.position(m), vs[m]);
   }
 }
 
@@ -247,7 +257,7 @@ TEST(InitConfigBuilder, MovePositionsSetsPerChain) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(2, 2).positions(std::move(vs)).build();
   for (std::size_t m = 0; m < 2; ++m) {
-    EXPECT_TRUE(cfg.position(m).isApprox(vs_expected[m]));
+    expect_near(cfg.position(m), vs_expected[m]);
   }
 }
 
@@ -291,7 +301,7 @@ TEST(InitConfigBuilder, RandomPositionsScaledByInitScale) {
   walnuts::InitConfig cfg2 =
       walnuts::InitConfigBuilder(2, 3).positions(rng2, 2.0).build();
   for (std::size_t n = 0; n < 2; ++n) {
-    EXPECT_TRUE(cfg2.position(n).isApprox(2.0 * cfg1.position(n)));
+    expect_near(cfg2.position(n), (2.0 * cfg1.position(n)).eval());
   }
 }
 
@@ -311,7 +321,7 @@ TEST(InitConfigBuilder, ScalarMassSetsAllChains) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(3, 2).masses(mass).build();
   for (std::size_t n = 0; n < 3; ++n) {
-    EXPECT_TRUE(cfg.mass(n).isApprox(mass));
+    expect_near(cfg.mass(n), mass);
   }
 }
 
@@ -343,7 +353,7 @@ TEST(InitConfigBuilder, VectorMassesSetsPerChain) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(3, 2).masses(vs).build();
   for (std::size_t m = 0; m < 3; ++m) {
-    EXPECT_TRUE(cfg.mass(m).isApprox(vs[m]));
+    expect_near(cfg.mass(m), vs[m]);
   }
 }
 
@@ -380,7 +390,7 @@ TEST(InitConfigBuilder, MoveMassesSetsPerChain) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(2, 2).masses(std::move(vs)).build();
   for (std::size_t n = 0; n < 2; ++n) {
-    EXPECT_TRUE(cfg.mass(n).isApprox(expected[n]));
+    expect_near(cfg.mass(n), expected[n]);
   }
 }
 
@@ -434,7 +444,7 @@ TEST(InitConfigBuilder, LogpGradMassesMatchHandCalculation) {
   Eigen::VectorXd expected(2);
   expected(0) = (1 - s) * std::sqrt(1.0) + s;
   expected(1) = (1 - s) * std::sqrt(2.0) + s;
-  EXPECT_TRUE(cfg.mass(0).isApprox(expected));
+  expect_near(cfg.mass(0), expected);
 }
 
 TEST(InitConfigBuilder, LogpGradMassesOneThrows) {
@@ -466,8 +476,8 @@ TEST(InitConfig, InitChainConfigReturnsCorrectValues) {
                                 .build();
   walnuts::InitChainConfig cc = cfg.init_chain_config(0);
   EXPECT_DOUBLE_EQ(cc.step_size(), 0.25);
-  EXPECT_TRUE(cc.position().isApprox(pos));
-  EXPECT_TRUE(cc.mass().isApprox(mass));
+  expect_near(cc.position(), pos);
+  expect_near(cc.mass(), mass);
 }
 
 // chaining 
@@ -898,13 +908,13 @@ TEST(SamplingConfigBuilder, FullChainProducesCorrectConfig) {
       .min_micro_steps(2)
       .rhat_converge_tol(1.05)
       .build();
-  EXPECT_EQ(cfg.min_iter(),                   std::size_t{25});
-  EXPECT_EQ(cfg.max_iter(),                   std::size_t{200});
-  EXPECT_EQ(cfg.max_trajectory_doublings(),   std::size_t{8});
-  EXPECT_EQ(cfg.max_step_halvings(),          std::size_t{3});
+  EXPECT_EQ(cfg.min_iter(), std::size_t{25});
+  EXPECT_EQ(cfg.max_iter(), std::size_t{200});
+  EXPECT_EQ(cfg.max_trajectory_doublings(), std::size_t{8});
+  EXPECT_EQ(cfg.max_step_halvings(), std::size_t{3});
   EXPECT_DOUBLE_EQ(cfg.max_hamiltonian_error(), 1.0);
-  EXPECT_EQ(cfg.min_micro_steps(),            std::size_t{2});
-  EXPECT_DOUBLE_EQ(cfg.rhat_converge_tol(),   1.05);
+  EXPECT_EQ(cfg.min_micro_steps(), std::size_t{2});
+  EXPECT_DOUBLE_EQ(cfg.rhat_converge_tol(), 1.05);
 }
 
 TEST(SamplingConfigBuilder, ChainingReferenceEquality) {

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -6,55 +6,7 @@
 #include <vector>
 
 #include <walnuts.hpp>
-
-static std::vector<double> inf_nan() {
-  std::vector<double> result;
-  result.push_back(std::numeric_limits<double>::quiet_NaN());
-  result.push_back(std::numeric_limits<double>::infinity());
-  return result;
-}
-
-static std::vector<double> inf_nan_neg() {
-  std::vector<double> result = inf_nan();
-  result.push_back(-0.3);
-  return result;
-}
-
-static std::vector<double> inf_nan_neg_zero() {
-  std::vector<double> result = inf_nan_neg();
-  result.push_back(0.0);
-  return result;
-}
-
-static std::vector<double> inf_nan_neg_zero_geq_one() {
-  std::vector<double> result = inf_nan_neg_zero();
-  result.push_back(1.0);
-  result.push_back(1.5);
-  return result;
-}
-
-static std::vector<double> inf_nan_neg_zero_leq_one() {
-  std::vector<double> result = inf_nan_neg_zero();
-  result.push_back(1.0);
-  result.push_back(0.99);
-  return result;
-}
-
-template <int R, int C>
-static void expect_near(const Eigen::Matrix<double, R, C>& x,
-			const Eigen::Matrix<double, R, C>& y,
-			double tolerance = 1e-10) {
-  EXPECT_EQ(x.size(), y.size());
-  for (Eigen::Index n = 0; n < x.size(); ++n) {
-    EXPECT_NEAR(x(n), y(n), tolerance);
-  }
-}
-
-static void std_normal(const Eigen::VectorXd& x, double& lp,
-                       Eigen::VectorXd& grad) {
-  lp = -0.5 * x.dot(x);
-  grad = -x;
-}
+#include <../tests/test_util.hpp>
 
 // class InitChainConfig ********************************************
 

--- a/tests/summary_test.cpp
+++ b/tests/summary_test.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <walnuts.hpp>
+#include <../tests/test_util.hpp>
 
 // MarkovChainsSplit class ******************************************
 
@@ -67,7 +68,7 @@ TEST(MarkovChainsSplit, ChainViewReturnsCorrectChain) {
     Eigen::MatrixXd view = mcs.chain_view(m);
     ASSERT_EQ(view.rows(), chains[m].rows());
     ASSERT_EQ(view.cols(), chains[m].cols());
-    EXPECT_TRUE(view.isApprox(chains[m]));
+    expect_near(view, chains[m]);
   }
 }
 
@@ -94,8 +95,8 @@ TEST(MarkovChainsSplit, DrawsConcatenatesAcrossChains) {
 
   ASSERT_EQ(d0.size(), Eigen::Index{8});
   ASSERT_EQ(d1.size(), Eigen::Index{8});
-  EXPECT_TRUE(d0.isApprox(expected_d0));
-  EXPECT_TRUE(d1.isApprox(expected_d1));
+  expect_near(d0, expected_d0);
+  expect_near(d1, expected_d1);
 }
 
 TEST(MarkovChainsSplit, DrawsThrowsOnOutOfRangeDimension) {
@@ -176,10 +177,11 @@ TEST(MarkovChainsUnified, ChainViewReturnsCorrectRows) {
   expected1 << 5, 6, 7, 8, 9, 10;
   Eigen::MatrixXd expected2(3, 2);
   expected2 << 11, 12, 13, 14, 15, 16;
+  std::vector<Eigen::MatrixXd> expected{expected0, expected1, expected2};
 
-  EXPECT_TRUE(mcu.chain_view(0).isApprox(expected0));
-  EXPECT_TRUE(mcu.chain_view(1).isApprox(expected1));
-  EXPECT_TRUE(mcu.chain_view(2).isApprox(expected2));
+  for (std::size_t n = 0; n < expected.size(); ++n) {
+    expect_near(mcu.chain_view(n).eval(), expected[n]);
+  }
 }
 
 TEST(MarkovChainsUnified, ChainViewIsAViewNotACopy) {
@@ -209,8 +211,8 @@ TEST(MarkovChainsUnified, DrawsReturnsCorrectColumn) {
 
   ASSERT_EQ(mcu.draws(0).size(), Eigen::Index{8});
   ASSERT_EQ(mcu.draws(1).size(), Eigen::Index{8});
-  EXPECT_TRUE(mcu.draws(0).isApprox(expected_d0));
-  EXPECT_TRUE(mcu.draws(1).isApprox(expected_d1));
+  expect_near(mcu.draws(0).eval(), expected_d0);
+  expect_near(mcu.draws(1).eval(), expected_d1);
 }
 
 TEST(MarkovChainsUnified, DrawsIsAViewNotACopy) {
@@ -303,8 +305,8 @@ TEST(SampleVariance, BothTypesAgreeOnSameData) {
   walnuts::MarkovChainsSplit mcs(chains);
   Eigen::MatrixXd draws = make_unified_draws();
   walnuts::MarkovChainsUnified mcu(draws, chain_sizes);
-  EXPECT_TRUE(
-      walnuts::sample_variance(mcs).isApprox(walnuts::sample_variance(mcu)));
+  expect_near(walnuts::sample_variance(mcs),
+	      walnuts::sample_variance(mcu));
 }
 
 TEST(SampleVariance, ResultSizeMatchesDims) {
@@ -375,7 +377,7 @@ TEST(SampleStandardDeviation, IsSquareRootOfSampleVariance) {
   walnuts::MarkovChainsSplit mcs(chains);
   Eigen::RowVectorXd sd = walnuts::sample_standard_deviation(mcs);
   Eigen::RowVectorXd v = walnuts::sample_variance(mcs);
-  EXPECT_TRUE(sd.array().square().matrix().isApprox(v));
+  expect_near(sd.array().square().matrix().eval(), v);
 }
 
 TEST(SampleStandardDeviation, TwoIdenticalDrawsGivesZeroStdDev) {
@@ -540,7 +542,7 @@ TEST(Quantiles, QuartilesMatchNumpy) {
   Eigen::MatrixXd result = walnuts::quantiles(mcs, probs);
   Eigen::MatrixXd expected(5, 2);
   expected << 1.0, 2.0, 4.5, 5.5, 8.0, 9.0, 11.5, 12.5, 15.0, 16.0;
-  EXPECT_TRUE(result.isApprox(expected));
+  expect_near(result, expected);
 }
 
 TEST(Quantiles, InteriorProbsMatchNumpy) {
@@ -551,7 +553,7 @@ TEST(Quantiles, InteriorProbsMatchNumpy) {
   Eigen::MatrixXd result = walnuts::quantiles(mcs, probs);
   Eigen::MatrixXd expected(3, 2);
   expected << 2.4, 3.4, 9.4, 10.4, 13.6, 14.6;
-  EXPECT_TRUE(result.isApprox(expected));
+  expect_near(result, expected);
 }
 
 // example from the documentation
@@ -577,8 +579,8 @@ TEST(Quantiles, BothTypesAgreeOnSameData) {
   walnuts::MarkovChainsUnified mcu(draws, chain_sizes);
   Eigen::VectorXd probs(5);
   probs << 0.0, 0.25, 0.5, 0.75, 1.0;
-  EXPECT_TRUE(
-      walnuts::quantiles(mcs, probs).isApprox(walnuts::quantiles(mcu, probs)));
+  expect_near(walnuts::quantiles(mcs, probs),
+	      walnuts::quantiles(mcu, probs));
 }
 
 // autocovariance() function ****************************************
@@ -674,7 +676,7 @@ TEST(Autocovariance, FullResultMatchesReference) {
       -16.0 / 3.0, -64.0 / 27.0,  // chain 2, lag 1
       1.0, 7.0 / 27.0;            // chain 2, lag 2
 
-  EXPECT_TRUE(acov.isApprox(expected, 1e-10));
+  expect_near(acov, expected);
 }
 
 // check FFT vs. direct
@@ -689,7 +691,7 @@ TEST(Autocovariance, MatchesDirectComputationPerChain) {
     Eigen::MatrixXd chain = mcs.chain_view(m);
     Eigen::MatrixXd direct = autocovariance_direct(chain);
     Eigen::MatrixXd fft_block = acov.middleRows(starts[m], sizes[m]);
-    EXPECT_TRUE(fft_block.isApprox(direct, 1e-10)) << "Mismatch at chain " << m;
+    expect_near(fft_block, direct);
   }
 }
 
@@ -712,8 +714,8 @@ TEST(Autocovariance, BothTypesAgreeOnSameData) {
   Eigen::MatrixXd draws(8, 2);
   draws << 1, 2, 4, 6, 3, 8, 7, 1, 2, 9, 6, 4, 1, 7, 8, 2;
   walnuts::MarkovChainsUnified mcu(draws, {2, 3, 3});
-  EXPECT_TRUE(walnuts::autocovariance(mcs).isApprox(
-      walnuts::autocovariance(mcu), 1e-10));
+  expect_near(walnuts::autocovariance(mcs),
+	      walnuts::autocovariance(mcu));
 }
 
 // single draw chain
@@ -899,7 +901,7 @@ TEST(RHat, BothTypesAgreeOnSameData) {
   draws << 1, 10, 2, 8, 3, 9, 4, 5, 6, 7, 5, 6, 7, 2, 9, 4, 8, 3;
   walnuts::MarkovChainsUnified mcu(draws, {3, 3, 3});
 
-  EXPECT_TRUE(walnuts::r_hat(mcs).isApprox(walnuts::r_hat(mcu)));
+  expect_near(walnuts::r_hat(mcs), walnuts::r_hat(mcu));
 }
 
 // effective_sample_size() function *********************************
@@ -1111,8 +1113,8 @@ TEST(EffectiveSampleSize, BothTypesAgreeOnSameData) {
   draws << c0, c1, c2;  // Eigen comma-init stacks row blocks
   walnuts::MarkovChainsUnified mcu(draws, {20, 20, 20});
 
-  EXPECT_TRUE(walnuts::effective_sample_size(mcs).isApprox(
-      walnuts::effective_sample_size(mcu), 1e-10));
+  expect_near(walnuts::effective_sample_size(mcs),
+	      walnuts::effective_sample_size(mcu));
 }
 
 // test tau_hat floor at 1/log10(N_total)
@@ -1176,7 +1178,7 @@ TEST(MonteCarloStandardError, EqualsStdDevOverSqrtEss) {
   Eigen::RowVectorXd mcse = walnuts::monte_carlo_standard_error(mcs);
   Eigen::RowVectorXd sd = walnuts::sample_standard_deviation(mcs);
   Eigen::RowVectorXd ess = walnuts::effective_sample_size(mcs);
-  EXPECT_TRUE(mcse.isApprox((sd.array() / ess.array().sqrt()).matrix(), 1e-10));
+  expect_near(mcse, (sd.array() / ess.array().sqrt()).matrix().eval());
 }
 
 // matches reference test case
@@ -1219,6 +1221,6 @@ TEST(MonteCarloStandardError, BothTypesAgreeOnSameData) {
   draws << c0, c1, c2;
   walnuts::MarkovChainsUnified mcu(draws, {20, 20, 20});
 
-  EXPECT_TRUE(walnuts::monte_carlo_standard_error(mcs).isApprox(
-      walnuts::monte_carlo_standard_error(mcu), 1e-10));
+  expect_near(walnuts::monte_carlo_standard_error(mcs),
+	      walnuts::monte_carlo_standard_error(mcu));
 }

--- a/tests/test_util.hpp
+++ b/tests/test_util.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <limits>
+#include <vector>
+
+#include <Eigen/Dense>
+
+static std::vector<double> inf_nan() {
+  std::vector<double> result;
+  result.push_back(std::numeric_limits<double>::quiet_NaN());
+  result.push_back(std::numeric_limits<double>::infinity());
+  return result;
+}
+
+static std::vector<double> inf_nan_neg() {
+  std::vector<double> result = inf_nan();
+  result.push_back(-0.3);
+  return result;
+}
+
+static std::vector<double> inf_nan_neg_zero() {
+  std::vector<double> result = inf_nan_neg();
+  result.push_back(0.0);
+  return result;
+}
+
+static std::vector<double> inf_nan_neg_zero_geq_one() {
+  std::vector<double> result = inf_nan_neg_zero();
+  result.push_back(1.0);
+  result.push_back(1.5);
+  return result;
+}
+
+static std::vector<double> inf_nan_neg_zero_leq_one() {
+  std::vector<double> result = inf_nan_neg_zero();
+  result.push_back(1.0);
+  result.push_back(0.99);
+  return result;
+}
+
+template <int R, int C>
+static void expect_near(const Eigen::Matrix<double, R, C>& x,
+			const Eigen::Matrix<double, R, C>& y,
+			double tolerance = 1e-10) {
+  EXPECT_EQ(x.size(), y.size());
+  for (Eigen::Index n = 0; n < x.size(); ++n) {
+    EXPECT_NEAR(x(n), y(n), tolerance);
+  }
+}
+
+static void std_normal(const Eigen::VectorXd& x, double& lp,
+                       Eigen::VectorXd& grad) {
+  lp = -0.5 * x.dot(x);
+  grad = -x;
+}


### PR DESCRIPTION
This fixes two problems:

* uninitialized memory in autocovariance fixed in the implementation so that all platforms agree
* linking windows/gcc in the makefiles so that all platforms build

I separated out a utilities file for testing.  Luckily, windows seems OK with my clunky includes:

```cpp
#include <../tests/test_util.hpp>
```

