### PR TITLE
Silence warning for possibly-uninitialized variable

### DIFF
--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <random>
 #include <stdexcept>
@@ -426,8 +427,8 @@ static std::optional<SpanW> build_leaf(const F& logp_grad, const SpanW& span,
   Eigen::VectorXd theta_next;
   Eigen::VectorXd rho_next;
   Eigen::VectorXd grad_theta_next;
-  double logp_pos_next;
-  double logp_next;
+  double logp_pos_next = -std::numeric_limits<double>::infinity();
+  double logp_next = -std::numeric_limits<double>::infinity();
   if (!macro_step<D>(logp_grad, inv_mass, step, max_step_halvings,
                      min_micro_steps, max_error, span, theta_next, rho_next,
                      grad_theta_next, logp_pos_next, logp_next,

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -427,6 +427,7 @@ static std::optional<SpanW> build_leaf(const F& logp_grad, const SpanW& span,
   Eigen::VectorXd theta_next;
   Eigen::VectorXd rho_next;
   Eigen::VectorXd grad_theta_next;
+  // values are dummies; will be reset by macro step
   double logp_pos_next = -std::numeric_limits<double>::infinity();
   double logp_next = -std::numeric_limits<double>::infinity();
   if (!macro_step<D>(logp_grad, inv_mass, step, max_step_halvings,


### PR DESCRIPTION
My compiler was complaining about these out parameters of the `macro_step` function, since it couldn't be certain that the supplied `logp_grad` actually set anything before their first usage