### PR TITLE
fix variance denominator; adjust converge tols; fixes #67

### DIFF
--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -63,14 +63,15 @@ int main() {
 
   auto warmup_cfg = walnuts::WarmupConfigBuilder()
                         .min_max_iter(50, 2000)
-                        .step_size_converge_tol(1)
+                        .mass_converge_tol(2.0)    
+                        .step_size_converge_tol(0.2)
                         .mass_init_count(4.0)
                         .build();
 
   auto sampling_cfg = walnuts::SamplingConfigBuilder()
                           .min_max_iter(50, 10000)
                           .max_trajectory_doublings(8)
-                          .rhat_converge_tol(1.0001)
+                          .rhat_converge_tol(1.001)
                           .build();
 
   // std::cout << init_cfg << "\n\n";  // too verbose with multi-chain

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -303,7 +303,7 @@ inline std::size_t sum(const std::vector<std::size_t>& xs) noexcept {
  * @return The variance.
  */
 inline double variance(const Eigen::VectorXd& xs) noexcept {
-  return (xs.array() - xs.mean()).square().mean() /
+  return (xs.array() - xs.mean()).square().sum() /
          static_cast<double>((xs.size() - 1));
 }
 


### PR DESCRIPTION
Fixing issue #67---wrong denominator in the variance calculation.  Also adjusts the tolerances in the demo to match.