### PR TITLE
Fix geometric mean / add non-threaded example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_executable(examples examples.cpp) 
+target_link_libraries(examples PRIVATE walnuts)
+target_compile_options(examples PRIVATE -O3 -Wall)
+
 option(WALNUTS_USE_TSAN "Build examples with ThreadSanitizer" OFF)
 
 # Apply the standard example flags plus TSan if enabled

--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -86,29 +86,14 @@ static void run_adaptive_walnuts(F& target_logp_grad) {
   std::size_t D = 100;
 
   auto init_cfg = walnuts::InitConfigBuilder(num_chains, D)
-                      // .step_sizes(0.5)
-                      // .positions(rng, 1.0)
-                      // .masses(target_logp_grad, 0.01)
     .build();
 
   auto warmup_cfg = walnuts::WarmupConfigBuilder()
     .min_max_iter(50, 200)
-                        // .mass_converge_tol(2.0)
-                        // .step_size_converge_tol(0.2)
-                        // .mass_init_count(1.1)
-                        // .step_accept_rate_target(0.8)
-                        // .step_learning_rate(0.2)
-                        // .step_gradient_decay(0.3)
-                        // .step_sq_gradient_decay(0.99)
-                        // .step_stabilization(1e-4)
     .build();
 
   auto sampling_cfg = walnuts::SamplingConfigBuilder()
                           .min_max_iter(50, 1000)
-                          // .min_micro_steps(1)
-                          // .max_trajectory_doublings(8)
-                          // .max_step_halvings(5)
-                          // .rhat_converge_tol(1.001)
     .build();
 
   std::cout << "Initialization configuration:\n" << init_cfg << std::endl;

--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -1,0 +1,146 @@
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <walnuts.hpp>
+
+static double total_time = 0.0;
+static std::size_t count = 0;
+
+// p(y) = normal(y | 0, I)
+static void std_normal(const Eigen::VectorXd& x, double& logp,
+                                 Eigen::VectorXd& grad) {
+  logp = -0.5 * x.dot(x);
+  grad = -x;
+}
+
+// p(y) = normal(0, diag(sigma)), sigma[d] = d
+static void ill_normal(const Eigen::VectorXd& x, double& logp,
+		       Eigen::VectorXd& grad) {
+  const auto D = x.size();
+  grad = Eigen::VectorXd::Zero(D);
+  logp = 0;
+  for (auto d = 0; d < D; ++d) {
+    double sigma = d + 1;
+    double sigma_sq = sigma * sigma;
+    logp += -0.5 * x[d] * x[d] / sigma_sq;
+    grad[d] = -x[d] / sigma_sq;
+  }
+}
+
+// p(y) = normal(y | 0, Sigma), with Sigma[i, j] = rho^abs(i - j)
+static void rw1(const Eigen::VectorXd& y, double& logp,
+		Eigen::VectorXd& grad) {
+  double rho = 0.99;
+  Eigen::Index D = y.size();
+  double sigma_sq = 1.0 - rho * rho;
+  double inv_sigma_sq = 1.0 / sigma_sq;
+  grad.setZero(D);
+  logp = -0.5 * y[0] * y[0];
+  grad[0] -= y[0];
+  for (Eigen::Index n = 1; n < D; ++n) {
+    double r = y[n] - rho * y[n - 1];
+    double w = r * inv_sigma_sq;
+    logp -= 0.5 * r * w;
+    grad[n] -= w;
+    grad[n - 1] += rho * w;
+  }
+}
+
+static void summarize(const Eigen::MatrixXd& draws) {
+  auto D = draws.cols();
+  auto N = draws.rows();
+  for (auto d = 0; d < D; ++d) {
+    if (d >= 3 && d < D - 3) {
+      if (d == 4) {
+        std::cout << "... elided " << (D - 6) << " rows ..." << std::endl;
+      }
+      continue;
+    }
+    auto mean = draws.col(d).mean();
+    auto var = (draws.col(d).array() - mean).square().sum() / (N - 1);
+    auto stddev = std::sqrt(var);
+    std::cout << "dim " << d << ": mean = " << mean << ", stddev = " << stddev
+              << "\n";
+  }
+}
+
+static void summarize(const std::vector<Eigen::VectorXd>& draws) {
+  Eigen::MatrixXd draws_mat(draws.size(), draws[0].size());
+  for (std::size_t n = 0; n < draws.size(); ++n) {
+    draws_mat.row(n) = draws[n].transpose();
+  }
+  return summarize(draws_mat);
+}
+
+
+template <typename F>
+static void run_adaptive_walnuts(F& target_logp_grad) {
+  std::cout << "\nRUN ADAPTIVE WALNUTS" << std::endl;
+
+  unsigned int seed = 876254;
+  std::mt19937 rng(seed);
+
+  std::size_t num_chains = 1;
+  std::size_t D = 100;
+
+  auto init_cfg = walnuts::InitConfigBuilder(num_chains, D)
+                      // .step_sizes(0.5)
+                      // .positions(rng, 1.0)
+                      // .masses(target_logp_grad, 0.01)
+    .build();
+
+  auto warmup_cfg = walnuts::WarmupConfigBuilder()
+    .min_max_iter(50, 200)
+                        // .mass_converge_tol(2.0)
+                        // .step_size_converge_tol(0.2)
+                        // .mass_init_count(1.1)
+                        // .step_accept_rate_target(0.8)
+                        // .step_learning_rate(0.2)
+                        // .step_gradient_decay(0.3)
+                        // .step_sq_gradient_decay(0.99)
+                        // .step_stabilization(1e-4)
+    .build();
+
+  auto sampling_cfg = walnuts::SamplingConfigBuilder()
+                          .min_max_iter(50, 1000)
+                          // .min_micro_steps(1)
+                          // .max_trajectory_doublings(8)
+                          // .max_step_halvings(5)
+                          // .rhat_converge_tol(1.001)
+    .build();
+
+  std::cout << "Initialization configuration:\n" << init_cfg << std::endl;
+  std::cout << "Warmup configuration:\n" << warmup_cfg << std::endl;
+  std::cout << "Sampling configuration:\n" << sampling_cfg << std::endl;
+
+  walnuts::ChainStore handler;
+  walnuts::AdaptiveWalnuts adapt(rng, handler, target_logp_grad, 
+				 init_cfg.init_chain_config(0), warmup_cfg, sampling_cfg);
+
+  for (std::size_t n = 0; n < warmup_cfg.max_iter(); ++n) {
+    adapt();
+  }
+  auto sample = adapt.sampler();
+  for (std::size_t n = 0; n < sampling_cfg.max_iter(); ++n) {
+    sample();
+  }
+
+  summarize(handler.draws());
+  std::cout << std::endl;
+  std::cout << "Micro step size = " << adapt.step_size() << std::endl;
+  std::cout << "Min micro steps per macro step = " << adapt.min_micro_steps()
+            << std::endl;
+  std::cout << "Inverse mass matrix = " << std::fixed << std::setprecision(2)
+            << adapt.inv_mass().transpose() << std::endl;
+}
+
+int main() {
+  auto target_logp_grad = std_normal;
+  // auto target_logp_grad = ill_normal;
+  // pauto target_logp_grad = rw1;
+
+  run_adaptive_walnuts(target_logp_grad);
+  return 0;
+}

--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -44,19 +44,22 @@ int main() {
   // 1) CONFIGUFRE =============================================================
   auto logp_grad = std_normal;
 
-  std::size_t seed = 48;
+  std::size_t seed = 48971425;
   std::seed_seq seed_seq_for_init{seed, static_cast<std::size_t>(0)};
   std::mt19937 rng{seed_seq_for_init};
   std::size_t num_chains = 32;
-  std::size_t dims = 1000;
+  std::size_t dims = 100;
 
   walnuts::CppInterruptCallback interrupt_callback;
   walnuts::GlobalStore global_handler;
   std::vector<walnuts::ChainStore> chain_handlers(num_chains);
 
-  double init_scale = 0.5;
+  
+
+  double init_scale = 1.0;
   double mass_smoothing = 0.1;
   auto init_cfg = walnuts::InitConfigBuilder(num_chains, dims)
+                      .step_sizes(0.5)
                       .positions(rng, init_scale)
                       .masses(std_normal, mass_smoothing)
                       .build();
@@ -65,12 +68,20 @@ int main() {
                         .min_max_iter(50, 2000)
                         .mass_converge_tol(2.0)
                         .step_size_converge_tol(0.2)
-                        .mass_init_count(4.0)
+                        .mass_init_count(1.1)
+                        .mass_additive_smoothing(0.1)
+                        .step_accept_rate_target(0.8)
+                        .step_learning_rate(0.2)
+                        .step_gradient_decay(0.3)
+                        .step_sq_gradient_decay(0.99)
+                        .step_stabilization(1e-4)
                         .build();
 
   auto sampling_cfg = walnuts::SamplingConfigBuilder()
+                          .min_micro_steps(1)
                           .min_max_iter(50, 10000)
                           .max_trajectory_doublings(8)
+                          .max_step_halvings(5)
                           .rhat_converge_tol(1.001)
                           .build();
 

--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -44,45 +44,32 @@ int main() {
   // 1) CONFIGUFRE =============================================================
   auto logp_grad = std_normal;
 
-  std::size_t seed = 48971425;
+  std::size_t seed = 48;
   std::seed_seq seed_seq_for_init{seed, static_cast<std::size_t>(0)};
   std::mt19937 rng{seed_seq_for_init};
-  std::size_t num_chains = 32;
-  std::size_t dims = 100;
+  std::size_t num_chains = 1;
+  std::size_t dims = 1000;
 
   walnuts::CppInterruptCallback interrupt_callback;
   walnuts::GlobalStore global_handler;
   std::vector<walnuts::ChainStore> chain_handlers(num_chains);
 
-  
-
-  double init_scale = 1.0;
-  double mass_smoothing = 0.1;
   auto init_cfg = walnuts::InitConfigBuilder(num_chains, dims)
-                      .step_sizes(0.5)
-                      .positions(rng, init_scale)
-                      .masses(std_normal, mass_smoothing)
+                      // .positions(rng, 1.0)
+                      // .masses(std_normal, 0.01)
                       .build();
 
   auto warmup_cfg = walnuts::WarmupConfigBuilder()
                         .min_max_iter(50, 2000)
-                        .mass_converge_tol(2.0)
-                        .step_size_converge_tol(0.2)
-                        .mass_init_count(1.1)
-                        .mass_additive_smoothing(0.1)
-                        .step_accept_rate_target(0.8)
-                        .step_learning_rate(0.2)
-                        .step_gradient_decay(0.3)
-                        .step_sq_gradient_decay(0.99)
-                        .step_stabilization(1e-4)
+                        // .mass_converge_tol(2.0)
+                        // .step_size_converge_tol(0.2)
+                        // .mass_init_count(4.0)
                         .build();
 
   auto sampling_cfg = walnuts::SamplingConfigBuilder()
-                          .min_micro_steps(1)
-                          .min_max_iter(50, 10000)
-                          .max_trajectory_doublings(8)
-                          .max_step_halvings(5)
-                          .rhat_converge_tol(1.001)
+                          .min_max_iter(50, 1000)
+                          // .max_trajectory_doublings(8)
+                          // .rhat_converge_tol(1.001)
                           .build();
 
   // std::cout << init_cfg << "\n\n";  // too verbose with multi-chain

--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -56,21 +56,14 @@ int main() {
   std::vector<walnuts::ChainStore> chain_handlers(num_chains);
 
   auto init_cfg = walnuts::InitConfigBuilder(num_chains, dims)
-                      // .positions(rng, 1.0)
-                      // .masses(std_normal, 0.01)
                       .build();
 
   auto warmup_cfg = walnuts::WarmupConfigBuilder()
                         .min_max_iter(50, 2000)
-                        // .mass_converge_tol(2.0)
-                        // .step_size_converge_tol(0.2)
-                        // .mass_init_count(4.0)
                         .build();
 
   auto sampling_cfg = walnuts::SamplingConfigBuilder()
                           .min_max_iter(50, 1000)
-                          // .max_trajectory_doublings(8)
-                          // .rhat_converge_tol(1.001)
                           .build();
 
   // std::cout << init_cfg << "\n\n";  // too verbose with multi-chain

--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -26,7 +26,8 @@ Eigen::VectorXd geom_mean_inv_mass(
   if (handlers.size() == 0) {
     return {};
   }
-  Eigen::VectorXd sum(handlers[0].diag_inv_mass().rows());
+  Eigen::VectorXd sum
+    = Eigen::VectorXd::Zero(handlers[0].diag_inv_mass().rows());
   for (const auto& handler : handlers) {
     sum += handler.diag_inv_mass().array().log().matrix();
   }
@@ -47,8 +48,8 @@ int main() {
   std::size_t seed = 48;
   std::seed_seq seed_seq_for_init{seed, static_cast<std::size_t>(0)};
   std::mt19937 rng{seed_seq_for_init};
-  std::size_t num_chains = 1;
-  std::size_t dims = 1000;
+  std::size_t num_chains = 32;
+  std::size_t dims = 100;
 
   walnuts::CppInterruptCallback interrupt_callback;
   walnuts::GlobalStore global_handler;


### PR DESCRIPTION
This PR does two things:

* it fixes the geometric mean in the `walnuts_api.cpp` example by initializing to zero (thanks for spotting, @WardBrian!)
* it adds a standalone `examples.cpp` to run an example of the API without multi-threading
* I also moved things back to having default initialization that matches between the two examples