### PR TITLE
allow geom avg mass matrix inits

### DIFF
--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -83,13 +83,31 @@ static void run_adaptive_walnuts(F& target_logp_grad) {
   std::size_t num_chains = 1;
   std::size_t D = 100;
 
-  auto init_cfg = walnuts::InitConfigBuilder(num_chains, D).build();
+  auto init_cfg = walnuts::InitConfigBuilder(num_chains, D)
+                      .positions(rng, 1.0)
+                      .masses(target_logp_grad, 0.01)
+                      .build();
 
-  auto warmup_cfg =
-      walnuts::WarmupConfigBuilder().min_max_iter(50, 200).build();
+  auto warmup_cfg = walnuts::WarmupConfigBuilder()
+                        .min_max_iter(50, 100)
+                        .mass_converge_tol(1.0)
+                        .step_size_converge_tol(0.1)
+                        .mass_init_count(4.0)
+                        .step_accept_rate_target(0.8)
+                        .step_learning_rate(0.05)
+                        .step_gradient_decay(0.8)
+                        .step_sq_gradient_decay(0.9)
+                        .step_stabilization(1e-4)
+                        .step_learn_rate_decay(0.95)
+                        .build();
 
-  auto sampling_cfg =
-      walnuts::SamplingConfigBuilder().min_max_iter(50, 1000).build();
+  auto sampling_cfg = walnuts::SamplingConfigBuilder()
+                          .min_max_iter(50, 1000)
+                          .min_micro_steps(1)
+                          .max_trajectory_doublings(8)
+                          .max_step_halvings(5)
+                          .rhat_converge_tol(1.001)
+                          .build();
 
   std::cout << "Initialization configuration:\n" << init_cfg << std::endl;
   std::cout << "Warmup configuration:\n" << warmup_cfg << std::endl;
@@ -118,10 +136,8 @@ static void run_adaptive_walnuts(F& target_logp_grad) {
 }
 
 int main() {
-  auto target_logp_grad = std_normal;
-  // auto target_logp_grad = ill_normal;
-  // pauto target_logp_grad = rw1;
-
-  run_adaptive_walnuts(target_logp_grad);
+  // run_adaptive_walnuts(std_normal);
+  // run_adaptive_walnuts(ill_normal);
+  run_adaptive_walnuts(rw1);
   return 0;
 }

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -334,30 +334,45 @@ class InitConfigBuilder {
    *
    * Following Nutpie (Seyboldt et al. 2026 @cite seyboldt2025nutpie),
    * the initialization uses a smoothed negative outer product of
-   * gradients.  More specifically, it uses the square root of the
-   * absolute value of the outer proudct of gradients linearly interpolated with
-   * a unit matrix with weight `mass_smoothing` on the unit matrix and `1 -
-   * mass_smoothing` on the regularized outer product.  This regularization goes
-   * beyond Nutpie to do the linear interpolation and also to take a square root
-   * to further regularize.
+   * gradient, which is the absolute value of the outer proudct of
+   * gradients linearly interpolated with a unit matrix with weight
+   * `mass_smoothing` on the unit matrix and `1 - mass_smoothing` on
+   * the regularized outer product.  This regularization goes beyond
+   * Nutpie to do the linear interpolation and also to take a square
+   * root to further regularize.
+   *
+   * If the flag `average_masses` is `true`, then each chain's mass
+   * matrix is set to the geometric average of the per-chain mass
+   * matrixes.
    *
    * @tparam LPG The type of the log density and gradient function.
    * @param[in] logp_grad The log density and gradient function, called back.
    * @param[in] mass_smoothing The additive smoothing for mass matrices.
+   * @param[in] average_masses Set to `true` to geometrically average mass
+   * matrices.
    * @throw std::invalid_argumet If the mass smoothing is not in (0, 1).
    * @return A reference to this builder for chaining.
    */
   template <LogpGrad F>
-  InitConfigBuilder& masses(const F& logp_grad, double mass_smoothing) {
+  InitConfigBuilder& masses(const F& logp_grad, double mass_smoothing,
+                            bool average_masses = false) {
     detail::validate_probability(mass_smoothing, "mass_smoothing");
     Eigen::VectorXd grad;
-    double lp;  // needed to calculate gradient, o.w. not used
     masses_.resize(num_chains_);
     for (std::size_t c = 0; c < num_chains_; ++c) {
-      logp_grad(positions_[c], lp, grad);
-      // abs geom averages with unit, sqrt additionally regularizes scale
-      masses_[c] =
-          (1 - mass_smoothing) * grad.array().abs().sqrt() + mass_smoothing;
+      double lp_to_discard;
+      logp_grad(positions_[c], lp_to_discard, grad);
+      masses_[c] = (1 - mass_smoothing) * grad.array().abs() + mass_smoothing;
+    }
+    if (average_masses) {
+      Eigen::Index D = masses_[0].size();
+      Eigen::VectorXd sum_log_mass = Eigen::VectorXd::Zero(D);
+      for (const auto& mass : masses_) {
+        sum_log_mass += mass.array().log().matrix();
+      }
+      auto avg_log_mass = sum_log_mass / num_chains_;
+      auto geom_mean_mass = avg_log_mass.array().exp().matrix();
+      masses_ = std::vector<Eigen::VectorXd>(num_chains_, geom_mean_mass);
     }
     return *this;
   }

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -231,7 +231,7 @@ class InitConfigBuilder {
    * @throw std::invalid_argument If any of the step sizes are not finite
    * positive.
    * @throw std::invalid_argument If the number of chains doesn't match the
-   * number specified in the constuctor.
+   * number specified in the constructor.
    */
   InitConfigBuilder& step_sizes(const std::vector<double>& v) {
     detail::validate_size(v, num_chains_, "step_sizes", "num_chains");
@@ -334,12 +334,10 @@ class InitConfigBuilder {
    *
    * Following Nutpie (Seyboldt et al. 2026 @cite seyboldt2025nutpie),
    * the initialization uses a smoothed negative outer product of
-   * gradient, which is the absolute value of the outer proudct of
+   * gradient, which is the absolute value of the outer product of
    * gradients linearly interpolated with a unit matrix with weight
    * `mass_smoothing` on the unit matrix and `1 - mass_smoothing` on
-   * the regularized outer product.  This regularization goes beyond
-   * Nutpie to do the linear interpolation and also to take a square
-   * root to further regularize.
+   * the regularized outer product.
    *
    * If the flag `average_masses` is `true`, then each chain's mass
    * matrix is set to the geometric average of the per-chain mass
@@ -1057,7 +1055,7 @@ inline std::ostream& operator<<(std::ostream& out, const SamplingConfig& cfg) {
 /**
  * @brief Encapsulated configuration for Walnuts.
  *
- * Walnuts configurations include initializaiton, warmup, and sampling
+ * Walnuts configurations include initialization, warmup, and sampling
  * configurations.
  */
 class WalnutsConfig {

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -143,7 +143,7 @@ TEST(InitConfigBuilder, ScalarPositionSetsAllChains) {
   walnuts::InitConfig cfg =
       walnuts::InitConfigBuilder(3, 2).positions(pos).build();
   for (std::size_t n = 0; n < 3; ++n) {
-    expect_near(cfg.position(n), pos);
+    expect_near(cfg.position(n), pos, 1e-10);
   }
 }
 
@@ -381,8 +381,8 @@ TEST(InitConfigBuilder, LogpGradMassesHaveCorrectShape) {
 
 TEST(InitConfigBuilder, LogpGradMassesMatchHandCalculation) {
   // pos = [1, 2];  grad = [-1, -2];  smooth = 0.5
-  // mass = (1 - smooth) * sqrt(abs(grad)) + smooth
-  //      = 0.5 * [sqrt(1), sqrt(2)] + 0.5 = [1, 0.5 * sqrt(2) + 0.5]
+  // mass = (1 - smooth) * abs(grad) + smooth
+  //      = 0.5 * [1, 2] + 0.5 = [1, 0.5 * sqrt(2) + 0.5]
   Eigen::VectorXd pos(2);
   pos << 1.0, 2.0;
   const double s = 0.5;
@@ -391,8 +391,8 @@ TEST(InitConfigBuilder, LogpGradMassesMatchHandCalculation) {
                                 .masses(std_normal, s)
                                 .build();
   Eigen::VectorXd expected(2);
-  expected(0) = (1 - s) * std::sqrt(1.0) + s;
-  expected(1) = (1 - s) * std::sqrt(2.0) + s;
+  expected(0) = (1 - s) * 1.0 + s;
+  expected(1) = (1 - s) * 2.0 + s;
   expect_near(cfg.mass(0), expected);
 }
 
@@ -408,6 +408,35 @@ TEST(InitConfigBuilder, LogpGradMassesThrowsOnInvalidSmoothing) {
   walnuts::InitConfigBuilder b(2, 2);
   for (auto x : inf_nan_neg()) {
     EXPECT_THROW(b.masses(std_normal, x), std::invalid_argument);
+  }
+}
+
+TEST(InitConfigBuilder, LogpGradMassesAveraged) {
+  for (auto sz : std::vector<double>{1, 2, 9, 32}) {
+    std::mt19937 rng(139872);
+    auto init_config = walnuts::InitConfigBuilder(sz, sz)
+                           .positions(rng, 1.0)
+                           .masses(std_normal, 0.01, false)
+                           .build();
+
+    std::mt19937 rng_avg(139872);
+    auto init_config_avg = walnuts::InitConfigBuilder(sz, sz)
+                               .positions(rng_avg, 1.0)
+                               .masses(std_normal, 0.01, true)
+                               .build();
+
+    auto masses = init_config.masses();
+    Eigen::VectorXd log_mass_sum = Eigen::VectorXd::Zero(sz);
+    for (const auto& mass : masses) {
+      log_mass_sum += mass.array().log().matrix();
+    }
+    auto mass_geom_avg = (log_mass_sum / sz).array().exp().matrix().eval();
+
+    std::cout << "avg: " << mass_geom_avg.transpose() << std::endl;
+    for (const auto& mass : init_config_avg.masses()) {
+      std::cout << "mass: " << mass.transpose() << std::endl;
+      // expect_near(mass, mass_geom_avg, 1e-10);
+    }
   }
 }
 


### PR DESCRIPTION
This is a simple PR that does two things around mass matrix init.

1.  Goes back to original nutpie inits of absolute gradient outer products geometrically averaged with unit.  The version being replaced further regularized with a square root.
2.  Allow averaged mass matrixes with a flag (issue #71). 