### PR TITLE
Fix possible dead hang when min_warmup_iter==max_warmup_iter

### DIFF
--- a/include/walnuts/adapt.hpp
+++ b/include/walnuts/adapt.hpp
@@ -139,9 +139,7 @@ class AdaptWorker {
         publish_snapshot(iter);
       }
     }
-    if (iter % warmup_config_.get().publish_stride() != 0) {
-      publish_snapshot(iter);
-    }
+    publish_snapshot(iter - 1);
   }
 
  private:


### PR DESCRIPTION
While writing some Python tests, I noticed I was occasionally getting hangs in the warmup loop. This ended up being because the worker threads would exit their adapting loop but never have reported the final number of iterations if the min/max were not exact multiples of the stride.

Fixing that revealed an off by one in which hit_max_iter in the controller loop was always false

The fix is relatively simple:

First: always publish a report at the end of the worker loop, regardless of the stride/current iteration.
Second: Observe that the loop has two exit conditions. The first is that a stop was requested at the start of an iteration. The second we've exceeded the max iters and exited. In both cases, we've had `iter` incremented but did not call `adapt()`. This means that outside the loop, we shouldn't report `iter`, but `iter-1`, as the number. 