### PR TITLE
Unify patterns between adaptation threaded code and sampling threaded code

### DIFF
--- a/include/walnuts/adapt.hpp
+++ b/include/walnuts/adapt.hpp
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <Eigen/Dense>
-#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <deque>
-#include <exception>
 #include <functional>
 #include <latch>
 #include <limits>
 #include <stop_token>
 #include <thread>
 #include <vector>
+
+#include <Eigen/Dense>
 
 #include "walnuts/concepts.hpp"
 #include "walnuts/config.hpp"
@@ -55,23 +54,15 @@ struct alignas(FALSE_SHARING_GUARD_SIZE) AdaptSnapshot {
 };
 
 /**
- * A triple buffer of adaptation snapshots.
- *
- * @see `walnuts::SpscBuffer`
- * @see `walnuts::AdaptSnapshot`
- */
-using Buffer = SpscBuffer<AdaptSnapshot>;
-
-/**
  * @brief Return a deque of buffers of the given sizes.
  *
  * @param[in] num_chains The number of Markov chains.
  * @param[in] dim The number of dimensions.
  * @return The buffer container.
  */
-inline std::deque<Buffer> construct_buffers(std::size_t num_chains,
-                                            std::size_t dim) {
-  std::deque<Buffer> buffers;
+inline std::deque<SpscBuffer<AdaptSnapshot>> construct_buffers(
+    std::size_t num_chains, std::size_t dim) {
+  std::deque<SpscBuffer<AdaptSnapshot>> buffers;
   auto snapshot = AdaptSnapshot(static_cast<Eigen::Index>(dim));
   for (std::size_t m = 0; m < num_chains; ++m) {
     buffers.emplace_back(snapshot);
@@ -91,23 +82,18 @@ class AdaptWorker {
   /**
    * @brief Construct an adaptation worker with the specified configuration.
    *
-   * @param[in] chain_id The identifier for which chain this is.
-   * @param[in] init_cfg The initialization configuragation.
    * @param[in] warmup_cfg The configuration for warmup.
-   * @param[in] buffer The buffer to hold the adaptation states.
-   * @param[in] start_gate A latch to gate work to start synchronously across
-   * workers.
    * @param[in] adapter The base sampler, methods of which are later called.
+   * @param[out] buffer The buffer to hold the adaptation states.
+   * @param[inout] start_gate A latch to gate work to start synchronously across
+   * workers.
    */
-  AdaptWorker(std::size_t chain_id, const InitConfig& init_cfg,
-              const WarmupConfig& warmup_cfg, Buffer& buffer,
-              std::latch& start_gate, A& adapter)
-      : chain_id_(chain_id),
-        init_config_(init_cfg),
-        warmup_config_(warmup_cfg),
+  AdaptWorker(const WarmupConfig& warmup_cfg, A& adapter,
+              SpscBuffer<AdaptSnapshot>& buffer, std::latch& start_gate)
+      : warmup_config_(warmup_cfg),
+        adapter_(adapter),
         buffer_(buffer),
-        start_gate_(start_gate),
-        adapter_(adapter) {}
+        start_gate_(start_gate) {}
 
   /**
    * @brief The functor called by the thread to do the adaptation.
@@ -153,12 +139,10 @@ class AdaptWorker {
     buffer_.get().publish();
   }
 
-  std::size_t chain_id_;
-  std::reference_wrapper<const InitConfig> init_config_;
   std::reference_wrapper<const WarmupConfig> warmup_config_;
-  std::reference_wrapper<Buffer> buffer_;
-  std::reference_wrapper<std::latch> start_gate_;
   std::reference_wrapper<A> adapter_;
+  std::reference_wrapper<SpscBuffer<AdaptSnapshot>> buffer_;
+  std::reference_wrapper<std::latch> start_gate_;
 };
 
 /**
@@ -180,55 +164,64 @@ struct AdaptResult {
  * @brief The implementation of the control monitor with the adaptation
  * state of each chain and configuration.
  *
- * @param[in,out] buffers The adaptation state of all the chains.
+ * @param[inout] buffers The adaptation state of all the chains.
  * @param[in] init_cfg The initialization configuration.
  * @param[in] warmup_cfg The warmup configuration.
  * @return Statistics for the completed adaptation process.
  */
 template <InterruptCallback IC>
-inline AdaptResult controller_loop(std::deque<Buffer>& buffers,
-                                   std::vector<AdaptSnapshot>& latest,
-                                   const IC& interrupt_callback,
-                                   const InitConfig& init_cfg,
-                                   const WarmupConfig& warmup_cfg) {
+inline AdaptResult controller_loop(
+    std::deque<SpscBuffer<AdaptSnapshot>>& buffers,
+    const IC& interrupt_callback, const InitConfig& init_cfg,
+    const WarmupConfig& warmup_cfg) {
   std::size_t M = init_cfg.num_chains();
   std::size_t D = init_cfg.dims();
 
+  std::vector<AdaptSnapshot> latest(init_cfg.num_chains());
   Eigen::VectorXd mean_log_mass(D);
   Eigen::VectorXd geom_mean_mass(D);
   Eigen::VectorXd scratch_mass(D);
+
+  std::size_t max_draws = M * warmup_cfg.max_iter();
   while (true) {
+    bool achieved_min_draws = true;
+    std::size_t num_draws = 0;
+
     mean_log_mass.setZero();
     double mean_log_step = 0.0;
-    std::size_t min_iter = std::numeric_limits<std::size_t>::max();
-    for (std::size_t m = 0; m < M; ++m) {
+
+    for (std::size_t m = 0; m < M && achieved_min_draws; ++m) {
       latest[m] = buffers[m].read_latest();
-      min_iter = std::min(min_iter, latest[m].iter);
+      if (latest[m].iter < warmup_cfg.min_iter()) {
+        achieved_min_draws = false;
+      }
+      num_draws += latest[m].iter;
+
       mean_log_step += latest[m].log_step;  // means after division
       mean_log_mass += latest[m].log_mass;
     }
-    mean_log_step /= static_cast<double>(M);
-    mean_log_mass /= static_cast<double>(M);
-    geom_mean_mass = mean_log_mass.array().exp().matrix();
+    if (achieved_min_draws) {
+      mean_log_step /= static_cast<double>(M);
+      mean_log_mass /= static_cast<double>(M);
+      geom_mean_mass = mean_log_mass.array().exp().matrix();
 
-    double max_rel_diff_mass = 0.0;
-    double max_rel_diff_step = 0.0;
-    double geom_mean_step = std::exp(mean_log_step);
-    for (std::size_t m = 0; m < M; ++m) {
-      double rel_diff_mass = l2_rel_diff(latest[m].mass, geom_mean_mass);
-      max_rel_diff_mass = std::fmax(max_rel_diff_mass, rel_diff_mass);
-      double chain_m_step = std::exp(latest[m].log_step);
-      double rel_diff_step = (chain_m_step - geom_mean_step) / geom_mean_step;
-      max_rel_diff_step = std::fmax(max_rel_diff_step, rel_diff_step);
-    }
+      double max_rel_diff_mass = 0.0;
+      double max_rel_diff_step = 0.0;
+      double geom_mean_step = std::exp(mean_log_step);
+      for (std::size_t m = 0; m < M; ++m) {
+        double rel_diff_mass = l2_rel_diff(latest[m].mass, geom_mean_mass);
+        max_rel_diff_mass = std::fmax(max_rel_diff_mass, rel_diff_mass);
+        double chain_m_step = std::exp(latest[m].log_step);
+        double rel_diff_step = (chain_m_step - geom_mean_step) / geom_mean_step;
+        max_rel_diff_step = std::fmax(max_rel_diff_step, rel_diff_step);
+      }
 
-    bool enough_iters = min_iter >= warmup_cfg.min_iter();
-    bool converged = enough_iters &&
-                     max_rel_diff_mass <= warmup_cfg.mass_converge_tol() &&
-                     max_rel_diff_step <= warmup_cfg.step_size_converge_tol();
-    bool hit_max_iter = min_iter == warmup_cfg.max_iter();
-    if (converged || hit_max_iter) {
-      return {geom_mean_mass, std::exp(mean_log_step)};
+      bool converged = max_rel_diff_mass <= warmup_cfg.mass_converge_tol() &&
+                       max_rel_diff_step <= warmup_cfg.step_size_converge_tol();
+      bool hit_max_iter = num_draws == max_draws;
+      if (converged || hit_max_iter) {
+        return {geom_mean_mass, std::exp(mean_log_step)};
+      }
     }
 
     interrupt_callback.throw_if_interrupted();
@@ -243,36 +236,26 @@ inline AdaptResult controller_loop(std::deque<Buffer>& buffers,
  * @tparam IC The type of the interrupt callback.
  * @param[in] init_cfg The initial configuration.
  * @param[in] warmup_cfg The warmup configuration.
- * @param[in,out] adapters The adaptive samplers for each chain.
+ * @param[inout] adapters The adaptive samplers for each chain.
  * @param[in] interrupt_callback The interrupt callback for stopping.
  */
 template <AdaptiveSampler A, InterruptCallback IC>
 inline void adapt(const InitConfig& init_cfg, const WarmupConfig& warmup_cfg,
                   std::vector<A>& adapters, const IC& interrupt_callback) {
-  std::deque<Buffer> buffers =
+  std::deque<SpscBuffer<AdaptSnapshot>> buffers =
       construct_buffers(init_cfg.num_chains(), init_cfg.dims());
+
   std::latch start_gate(static_cast<std::ptrdiff_t>(init_cfg.num_chains() + 1));
   std::vector<std::jthread> threads;
   threads.reserve(init_cfg.num_chains());
   for (std::size_t m = 0; m < init_cfg.num_chains(); ++m) {
-    threads.emplace_back(AdaptWorker<A>(m, init_cfg, warmup_cfg, buffers[m],
-                                        start_gate, adapters[m]));
+    threads.emplace_back(
+        AdaptWorker<A>(warmup_cfg, adapters[m], buffers[m], start_gate));
   }
-  std::vector<AdaptSnapshot> latest(init_cfg.num_chains());
   start_gate.arrive_and_wait();
-  AdaptResult result;
-  try {
-    result = controller_loop(buffers, latest, interrupt_callback, init_cfg,
-                             warmup_cfg);
-  } catch (const std::exception& e) {
-    for (auto& t : threads) {
-      t.request_stop();
-    }
-    throw(e);
-  }
-  for (auto& t : threads) {
-    t.request_stop();
-  }
+
+  AdaptResult result =
+      controller_loop(buffers, interrupt_callback, init_cfg, warmup_cfg);
 }
 
 }  // namespace walnuts::detail

--- a/include/walnuts/api.hpp
+++ b/include/walnuts/api.hpp
@@ -63,9 +63,8 @@ inline void walnuts(std::size_t seed, std::vector<H>& chain_handlers,
     samplers.emplace_back(std::move(adapters[n].sampler()));
   }
 
-  detail::sample(samplers, global_handler, interrupt_callback,
-                 config.sampling().rhat_converge_tol(),
-                 config.sampling().min_iter(), config.sampling().max_iter());
+  detail::sample(config.sampling(), samplers, global_handler,
+                 interrupt_callback);
 }
 
 }  // namespace walnuts

--- a/include/walnuts/sampler.hpp
+++ b/include/walnuts/sampler.hpp
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
-#include <exception>
 #include <functional>
 #include <latch>
 #include <stop_token>
@@ -13,6 +12,7 @@
 #include <Eigen/Dense>
 
 #include "walnuts/concepts.hpp"
+#include "walnuts/config.hpp"
 #include "walnuts/online_moments.hpp"
 #include "walnuts/spsc_buffer.hpp"
 #include "walnuts/util.hpp"
@@ -50,19 +50,16 @@ class ChainWorker {
   /**
    * @brief Construct a woker to embed in a thread for sampling.
    *
-   * @param[in] min_draws The minimum number of draws.
    * @param[in] max_draws The maximum number of draws.
    * @param[in] sampler The sampler.
    * @param[out] buffer The buffer of chain statistics for this chain.
-   * @param[in,out] start_gate The latch gating work and monitoring.
+   * @param[inout] start_gate The latch gating work and monitoring.
    * @param[in] yield_period The period in iterations of this thread
    * yielding.
    */
-  ChainWorker(std::size_t min_draws, std::size_t max_draws, S& sampler,
-              SpscBuffer<ChainStats>& buffer, std::latch& start_gate,
-              std::size_t yield_period = 1024)
-      : min_draws_(min_draws),
-        max_draws_(max_draws),
+  ChainWorker(std::size_t max_draws, S& sampler, SpscBuffer<ChainStats>& buffer,
+              std::latch& start_gate, std::size_t yield_period = 1024)
+      : max_draws_(max_draws),
         sampler_(sampler),
         buffer_(buffer),
         start_gate_(start_gate),
@@ -97,7 +94,6 @@ class ChainWorker {
   }
 
  private:
-  const std::size_t min_draws_;
   const std::size_t max_draws_;
   std::reference_wrapper<S> sampler_;
   WelfordAccumulator logp_stats_;
@@ -110,39 +106,36 @@ class ChainWorker {
  * @brief The function called by the controller to monitor the threads
  * for the chains.
  *
- * @param[in,out] stats_by_chain The per-chain objects holding the
+ * @param[inout] stats_by_chain The per-chain objects holding the
  * statistics to monitor.
- * @param[in] rhat_threshold When R-hat falls below this value, sampling
- * terminates.
- * @param[in,out] start_gate The latch gating the monitor and thread workers
- * to synchronize starting.
- * @param[in] min_draws_per_chain The minimum number of iterations per chain.
- * @param[in] max_draws_per_chain The maximum number of iterations per chain.
+ * @param[in] config The sampler configuration.
+ * @param[in] global_handler The callback for rhat values.
+ * @param[in] interrupt_callback The interrupt callback for stopping.
  * @param[in] eval_period The period between initiating cross-chain R-hat
  * calculations.
  */
 template <GlobalHandler GH, InterruptCallback IC>
 static void controller_loop(
     std::vector<SpscBuffer<ChainStats>>& stats_by_chain, GH& global_handler,
-    const IC& interrupt_callback, double rhat_threshold, std::latch& start_gate,
-    std::size_t min_draws_per_chain, std::size_t max_draws_per_chain,
+    const IC& interrupt_callback, const SamplingConfig& config,
     std::chrono::nanoseconds eval_period = std::chrono::milliseconds{1}) {
   interactive_qos();  // Apple silicon highest priority; o.w. no-op
   const std::size_t M = stats_by_chain.size();
   Eigen::VectorXd chain_means(M);
   Eigen::VectorXd chain_variances(M);
-  std::vector<std::size_t> counts(M, 0);
 
-  start_gate.arrive_and_wait();
   auto next = std::chrono::steady_clock::now() + eval_period;
+  std::size_t max_draws = M * config.max_iter();
   while (true) {
     bool achieved_min_draws = true;
+    std::size_t num_draws = 0;
     for (std::size_t m = 0; m < M && achieved_min_draws; ++m) {
       const ChainStats& u = stats_by_chain[m].read_latest();
-      counts[m] = u.count;
-      if (counts[m] < min_draws_per_chain) {
+      if (u.count < config.min_iter()) {
         achieved_min_draws = false;
       }
+      num_draws += u.count;
+
       chain_means(static_cast<Eigen::Index>(m)) = u.sample_mean;
       chain_variances(static_cast<Eigen::Index>(m)) = u.sample_var;
     }
@@ -151,8 +144,10 @@ static void controller_loop(
       double mean_of_variances = chain_variances.mean();
       double r_hat = std::sqrt(1 + variance_of_means / mean_of_variances);
       global_handler.on_r_hat(r_hat);
-      std::size_t num_draws = sum(counts);
-      if (r_hat <= rhat_threshold || num_draws == M * max_draws_per_chain) {
+
+      bool converged = r_hat <= config.rhat_converge_tol();
+      bool hit_max_iter = num_draws == max_draws;
+      if (converged || hit_max_iter) {
         return;
       }
     }
@@ -173,38 +168,27 @@ static void controller_loop(
  * @tparam S The type of the sampler.
  * @tparam GH The type of the global handler.
  * @tparam IC The type of the interrupt callback.
+ * @param[in] config The sampler configuration.
  * @param[in] samplers The vector of samplers.
- * @param[in,out] global_handler The global event handler for sampling.
+ * @param[inout] global_handler The global event handler for sampling.
  * @param[in] interrupt_callback The interrupt callback for stopping.
- * @param[in] rhat_threshold The threshold below which sampling is stopped.
- * @param[in] min_draws_per_chain The minimum number of draws per chain.
- * @param[in] max_draws_per_chain The maximum number of draws per chain.
  */
 template <Sampler S, GlobalHandler GH, InterruptCallback IC>
-inline void sample(std::vector<S>& samplers, GH& global_handler,
-                   const IC& interrupt_callback, double rhat_threshold,
-                   std::size_t min_draws_per_chain,
-                   std::size_t max_draws_per_chain) {
+inline void sample(const SamplingConfig& config, std::vector<S>& samplers,
+                   GH& global_handler, const IC& interrupt_callback) {
   std::size_t M = samplers.size();
-  std::vector<SpscBuffer<ChainStats>> stats_by_chain(M);
+  std::vector<SpscBuffer<ChainStats>> buffers(M);
   std::latch start_gate(static_cast<std::ptrdiff_t>(M + 1));
   std::vector<std::jthread> threads;
   threads.reserve(M);
   for (std::size_t m = 0; m < M; ++m) {
-    threads.emplace_back(ChainWorker<S>(min_draws_per_chain,
-                                        max_draws_per_chain, samplers[m],
-                                        stats_by_chain[m], start_gate));
+    threads.emplace_back(
+        ChainWorker<S>(config.max_iter(), samplers[m], buffers[m], start_gate));
   }
-  try {
-    controller_loop(stats_by_chain, global_handler, interrupt_callback,
-                    rhat_threshold, start_gate, min_draws_per_chain,
-                    max_draws_per_chain, std::chrono::milliseconds{1});
-  } catch (const std::exception& e) {
-    for (auto& t : threads) {
-      t.request_stop();
-    }
-    throw(e);
-  }
+
+  start_gate.arrive_and_wait();
+
+  controller_loop(buffers, global_handler, interrupt_callback, config);
 }
 
 }  // namespace walnuts::detail


### PR DESCRIPTION
I noticed while debugging #81 that sampler.hpp and adapt.hpp, despite being conceptually similar, had a ton of incidental differences in coding style that made it hard to transfer knowledge between the two files. 

The goal of this PR is just to make the two files look more like siblings; as a side effect, the adapt controller loop also now does a bunch less work, since it won't check anything until the minimum number of iterations is reached (the sampler already did this)