### PR TITLE
Init stepsize

### DIFF
--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -49,14 +49,16 @@ int main() {
   std::size_t seed = 48;
   std::seed_seq seed_seq_for_init{seed, static_cast<std::size_t>(0)};
   std::mt19937 rng{seed_seq_for_init};
-  std::size_t num_chains = 32;
+  std::size_t num_chains = 2;
   std::size_t dims = 100;
 
   walnuts::CppInterruptCallback interrupt_callback;
   walnuts::GlobalStore global_handler;
   std::vector<walnuts::ChainStore> chain_handlers(num_chains);
 
-  auto init_cfg = walnuts::InitConfigBuilder(num_chains, dims).build();
+  auto init_cfg = walnuts::InitConfigBuilder(num_chains, dims)
+    .step_sizes(100.2)  // test that adapt_step works with absurd init
+    .adapt_step_build(rng, logp_grad);
 
   auto warmup_cfg =
       walnuts::WarmupConfigBuilder().min_max_iter(50, 2000).build();

--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -49,7 +49,7 @@ int main() {
   std::size_t seed = 48;
   std::seed_seq seed_seq_for_init{seed, static_cast<std::size_t>(0)};
   std::mt19937 rng{seed_seq_for_init};
-  std::size_t num_chains = 2;
+  std::size_t num_chains = 4;
   std::size_t dims = 100;
 
   walnuts::CppInterruptCallback interrupt_callback;

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -465,52 +465,13 @@ class InitConfigBuilder {
   template <std::uniform_random_bit_generator RNG, LogpGrad F>
   InitConfig adapt_step_build(RNG& rng, const F& logp_grad) {
     for (std::size_t c = 0; c < num_chains_; ++c) {
-      step_sizes_[c] = adapt_step(rng, logp_grad, positions_[c],
-				  masses_[c], step_sizes_[c]);
+      step_sizes_[c] = detail::adapt_step(rng, logp_grad, positions_[c],
+					  masses_[c], step_sizes_[c], dims_);
     }
     return build();
   }
 
  private:
-  /**
-   * @brief Return the adapted step size for the specified initial
-   * step size, given an initial position and inverse mass matrix.
-   *
-   * The algorithm randomly generates a momentum.  Then until
-   * the Metropolis acceptance rate is below 0.9, it continues
-   * to double the step size.   Then until the Metropolis accept
-   * rate is above 0.6, it continues to divide it by sqrt(2).
-   * This is a slightly more fine-grained version of the heuristic
-   * step size initialization used by NUTS.
-   *
-   * @tparam RNG Type of the base random number generator.
-   * @tparam F Type of the log density and gradient function.
-   * @param[in] rng The base random number generator.
-   * @param[in] logp_grad The log density and gradient function.
-   * @param theta The initial position.
-   * @param M The diagonal of the diagonal mass matrix.
-   * @param step The initial step size guess.
-   * @return The adapted step size.
-   */
-  template <std::uniform_random_bit_generator RNG, LogpGrad F>
-  double adapt_step(RNG& rng, const F& logp_grad,
-		    const Eigen::VectorXd& theta,
-		    const Eigen::VectorXd& M,
-		    double step) {
-    detail::Random<RNG> rand(rng);
-    Eigen::VectorXd inv_M = M.array().inverse().matrix();
-    Eigen::VectorXd rho = (rand.standard_normal(static_cast<Eigen::Index>(dims_))
-			   .array() * M.array().sqrt()).matrix();
-    while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step)
-	   > std::log(0.9)) {
-      step *= 2;
-    }
-    while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) < std::log(0.6)) {
-      step *= std::sqrt(0.5);
-    }
-    return step;
-  }
-  
   std::size_t num_chains_;
   std::size_t dims_;
   std::vector<double> step_sizes_;

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -16,6 +16,8 @@
 
 namespace walnuts {
 
+  
+
 /**
  * @brief The initialization configuration for a single Markov chain.
  *
@@ -451,7 +453,63 @@ class InitConfigBuilder {
                       std::move(masses_)};
   }
 
+  /**
+   * @brief Heuristically adapt the initial step sizes, then return
+   * the initialization configuration.  
+   *
+   * @tparam RNG Type of the base random number generator.
+   * @tparam F Type of the log density and gradient function.
+   * @param[in] rng The base random number generator.
+   * @param[in] logp_grad The log density and gradient function.
+   */
+  template <std::uniform_random_bit_generator RNG, LogpGrad F>
+  InitConfig adapt_step_build(RNG& rng, const F& logp_grad) {
+    for (std::size_t c = 0; c < num_chains_; ++c) {
+      step_sizes_[c] = adapt_step(rng, logp_grad, positions_[c],
+				  masses_[c], step_sizes_[c]);
+    }
+    return build();
+  }
+
  private:
+  /**
+   * @brief Return the adapted step size for the specified initial
+   * step size, given an initial position and inverse mass matrix.
+   *
+   * The algorithm randomly generates a momentum.  Then until
+   * the Metropolis acceptance rate is below 0.9, it continues
+   * to double the step size.   Then until the Metropolis accept
+   * rate is above 0.6, it continues to divide it by sqrt(2).
+   * This is a slightly more fine-grained version of the heuristic
+   * step size initialization used by NUTS.
+   *
+   * @tparam RNG Type of the base random number generator.
+   * @tparam F Type of the log density and gradient function.
+   * @param[in] rng The base random number generator.
+   * @param[in] logp_grad The log density and gradient function.
+   * @param theta The initial position.
+   * @param inv_M The diagonal of the diagonal inverse mass matrix.
+   * @param step The initial step size guess.
+   * @return The adapted step size.
+   */
+  template <std::uniform_random_bit_generator RNG, LogpGrad F>
+  double adapt_step(RNG& rng, const F& logp_grad,
+		    const Eigen::VectorXd& theta,
+		    const Eigen::VectorXd& inv_M,
+		    double step) {
+    detail::Random<RNG> rand(rng);
+    Eigen::VectorXd rho = (rand.standard_normal(static_cast<Eigen::Index>(dims_))
+			   .array() / inv_M.array().sqrt()).matrix();
+    while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step)
+	   > std::log(0.9)) {
+      step *= 2;
+    }
+    while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) < std::log(0.6)) {
+      step *= std::sqrt(0.5);
+    }
+    return step;
+  }
+  
   std::size_t num_chains_;
   std::size_t dims_;
   std::vector<double> step_sizes_;

--- a/include/walnuts/config.hpp
+++ b/include/walnuts/config.hpp
@@ -488,18 +488,19 @@ class InitConfigBuilder {
    * @param[in] rng The base random number generator.
    * @param[in] logp_grad The log density and gradient function.
    * @param theta The initial position.
-   * @param inv_M The diagonal of the diagonal inverse mass matrix.
+   * @param M The diagonal of the diagonal mass matrix.
    * @param step The initial step size guess.
    * @return The adapted step size.
    */
   template <std::uniform_random_bit_generator RNG, LogpGrad F>
   double adapt_step(RNG& rng, const F& logp_grad,
 		    const Eigen::VectorXd& theta,
-		    const Eigen::VectorXd& inv_M,
+		    const Eigen::VectorXd& M,
 		    double step) {
     detail::Random<RNG> rand(rng);
+    Eigen::VectorXd inv_M = M.array().inverse().matrix();
     Eigen::VectorXd rho = (rand.standard_normal(static_cast<Eigen::Index>(dims_))
-			   .array() / inv_M.array().sqrt()).matrix();
+			   .array() * M.array().sqrt()).matrix();
     while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step)
 	   > std::log(0.9)) {
       step *= 2;

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -236,7 +236,7 @@ inline double logp_momentum(const Eigen::VectorXd& rho,
  * @tparam F The type of the log density and gradient function.
  * @param[in] theta The starting position.
  * @param[in] rho The starting momentum.
- * @param[in] inv_M The diagonal of the diagonal inverse mass matrix.
+ * @param[in] M The diagonal of the diagonal inverse mass matrix.
  * @param[in] step The step size.
  */
 template <LogpGrad F>

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -257,8 +257,52 @@ double leapfrog_error(const F& logp_grad,
   logp_star += detail::logp_momentum(rho_star, inv_M);
   double diff = logp_star - logp;
   return diff;
-}  
+}
 
+/**
+ * @brief Return the adapted step size for the specified initial
+ * step size, given an initial position and inverse mass matrix.
+ *
+ * The algorithm randomly generates a momentum.  Then until
+ * the Metropolis acceptance rate is below 0.9, it continues
+ * to double the step size.   Then until the Metropolis accept
+ * rate is above 0.6, it continues to divide it by sqrt(2).
+ * This is a slightly more fine-grained version of the heuristic
+ * step size initialization used by NUTS.
+ *
+ * There is no error testing here for consistency because this
+ * function is called from a controlled setting.
+ *
+ * @tparam RNG Type of the base random number generator.
+ * @tparam F Type of the log density and gradient function.
+ * @param[in] rng The base random number generator.
+ * @param[in] logp_grad The log density and gradient function.
+ * @param theta The initial position.
+ * @param M The diagonal of the diagonal mass matrix.
+ * @param step The initial step size guess.
+ * @param D The dimensioanlity
+ * @return The adapted step size.
+ */
+ template <std::uniform_random_bit_generator RNG, LogpGrad F>
+ double adapt_step(RNG& rng, const F& logp_grad,
+		   const Eigen::VectorXd& theta,
+		   const Eigen::VectorXd& M,
+		   double step,
+		   std::size_t D) {
+   detail::Random<RNG> rand(rng);
+   Eigen::VectorXd inv_M = M.array().inverse().matrix();
+   Eigen::VectorXd rho = (rand.standard_normal(static_cast<Eigen::Index>(D))
+			  .array() * M.array().sqrt()).matrix();
+   while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step)
+	  > std::log(0.9)) {
+     step *= 2;
+   }
+   while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) < std::log(0.6)) {
+     step *= std::sqrt(0.5);
+   }
+   return step;
+ }
+  
 /**
  * @brief A wrapper for a log density and gradient function that traps
  * exceptions.

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -223,6 +223,43 @@ inline double logp_momentum(const Eigen::VectorXd& rho,
 }
 
 /**
+ * @brief Return the difference in log density (negative Hamiltonian)
+ * between the intial position and momentum and the result of taking
+ * one leapfrog step with the specified inverse mass matrix and step size.
+ *
+ * As an internal function called by an algorithm that controls the
+ * inverse mass matrix and step size, there is no error checking to
+ * enusre `theta`, `rho`, and `inv_M` are all the same size, that
+ * `inv_M` has all finite positive entries, and that the step size is
+ * finite and positive.
+ *
+ * @tparam F The type of the log density and gradient function.
+ * @param[in] theta The starting position.
+ * @param[in] rho The starting momentum.
+ * @param[in] inv_M The diagonal of the diagonal inverse mass matrix.
+ * @param[in] step The step size.
+ */
+template <LogpGrad F>
+double leapfrog_error(const F& logp_grad,
+		      const Eigen::VectorXd& theta,
+		      const Eigen::VectorXd& rho,
+		      const Eigen::VectorXd& inv_M,
+		      double step) {
+  Eigen::VectorXd grad;
+  double logp;
+  logp_grad(theta, logp, grad);
+  logp += detail::logp_momentum(rho, inv_M);
+  Eigen::VectorXd rho_star = rho + 0.5 * step * grad;
+  Eigen::VectorXd theta_star = theta + step * (inv_M.array() * rho_star.array()).matrix();
+  double logp_star;
+  logp_grad(theta_star, logp_star, grad);
+  rho_star = rho_star + 0.5 * step * grad;
+  logp_star += detail::logp_momentum(rho_star, inv_M);
+  double diff = logp_star - logp;
+  return diff;
+}  
+
+/**
  * @brief A wrapper for a log density and gradient function that traps
  * exceptions.
  *

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include <../tests/test_util.hpp>
+#include "test_util.hpp"
 #include <walnuts.hpp>
 
 // class InitChainConfig ********************************************
@@ -475,6 +475,62 @@ TEST(InitConfigBuilder, MethodChainingReturnsBuilder) {
 
   chained_builder = chained_builder.positions(pos);
   EXPECT_EQ(&builder, &chained_builder);
+}
+
+// adapt_step_build (heuristic step init)
+
+TEST(InitConfigBuilder, AdaptStepBuildConvergesFromLowAndHigh) {
+  std::mt19937 rng_low(287456);
+  double low = walnuts::InitConfigBuilder(1, 3)
+                   .step_sizes(1e-4)
+                   .adapt_step_build(rng_low, std_normal)
+                   .step_size(0);
+  std::mt19937 rng_high(287456);
+  double high = walnuts::InitConfigBuilder(1, 3)
+                    .step_sizes(100.0)
+                    .adapt_step_build(rng_high, std_normal)
+                    .step_size(0);
+  // tiny step meets big step to within factor of 2
+  EXPECT_NEAR(std::log2(low), std::log2(high), 1.01);
+}
+
+double geo_mean_adapted_step(std::size_t D, double inv_mass,
+                             unsigned base_seed, int num_seeds) {
+  Eigen::VectorXd m =
+      Eigen::VectorXd::Constant(static_cast<Eigen::Index>(D), inv_mass);
+  double log_sum = 0.0;
+  for (int i = 0; i < num_seeds; ++i) {
+    std::mt19937 rng(base_seed + static_cast<unsigned>(i));
+    double s = walnuts::InitConfigBuilder(1, D)
+                   .masses(m)
+                   .adapt_step_build(rng, std_normal)
+                   .step_size(0);
+    log_sum += std::log(s);
+  }
+  return std::exp(log_sum / num_seeds);
+}
+
+TEST(InitConfigBuilder, AdaptStepScalesDownWithDimension) {
+  int rng_seed = 185737;
+  double h1     = geo_mean_adapted_step(1,     1.0, rng_seed, 256);
+  double h100   = geo_mean_adapted_step(100,   1.0, rng_seed, 64);
+  double h10000 = geo_mean_adapted_step(10000, 1.0, rng_seed, 16);
+
+  // optimal leapfrog step scales D^{-1/4} as D -> infinity
+  EXPECT_GT(h1, h100);
+  EXPECT_GT(h100, h10000);
+  EXPECT_NEAR(std::log(h100 / h10000), 0.25 * std::log(100.0), 0.5);
+  EXPECT_GT(h1 / h10000, 4.0);  
+}
+
+TEST(InitConfigBuilder, AdaptStepScalesWithInverseMass) {
+  int rng_seed = 285222;
+  const std::size_t D = 10;
+  double h_unit  = geo_mean_adapted_step(D, 1.0,   rng_seed, 1024);
+  double h_heavy = geo_mean_adapted_step(D, 100.0, rng_seed, 1024);
+  double h_light = geo_mean_adapted_step(D, 0.01,  rng_seed, 1024);
+  EXPECT_NEAR(h_heavy / h_unit, 10, 1);
+  EXPECT_NEAR(h_unit / h_light, 10, 1);
 }
 
 // classes WarmupConfig and WarmupConfigBuilder *********************

--- a/tests/test_util.hpp
+++ b/tests/test_util.hpp
@@ -5,6 +5,21 @@
 
 #include <Eigen/Dense>
 
+struct ThrowingLogpGrad {
+  void operator()(const Eigen::VectorXd& x, double& logp,
+                  Eigen::VectorXd& grad) const {
+    throw std::runtime_error("logp_grad failed");
+  }
+};
+
+struct GoodLogpGrad {
+  void operator()(const Eigen::VectorXd& x, double& logp,
+                  Eigen::VectorXd& grad) const {
+    logp = -0.5 * x.squaredNorm();
+    grad = -x;
+  }
+};
+
 static std::vector<double> inf_nan() {
   std::vector<double> result;
   result.push_back(std::numeric_limits<double>::quiet_NaN());

--- a/tests/util_test.cpp
+++ b/tests/util_test.cpp
@@ -267,21 +267,6 @@ TEST(LogpMomentum, KnownValueLinearTransform) {
 
 // NoExceptLogpGrad class *******************************************
 
-struct ThrowingLogpGrad {
-  void operator()(const Eigen::VectorXd& x, double& logp,
-                  Eigen::VectorXd& grad) const {
-    throw std::runtime_error("logp_grad failed");
-  }
-};
-
-struct GoodLogpGrad {
-  void operator()(const Eigen::VectorXd& x, double& logp,
-                  Eigen::VectorXd& grad) const {
-    logp = -0.5 * x.squaredNorm();
-    grad = -x;
-  }
-};
-
 TEST(NoExceptLogpGrad, NormalEvaluation) {
   GoodLogpGrad f;
   walnuts::detail::NoExceptLogpGrad wrapped(f);
@@ -390,4 +375,101 @@ TEST(DetailVariance, ShiftInvariantQuadraticScale) {
   EXPECT_DOUBLE_EQ(
       walnuts::detail::variance((5.7 + (13.2 * xs).array()).matrix()),
       13.2 * 13.2 * walnuts::detail::variance(xs));
+}
+
+// leapfrog_error() function ****************************************
+
+double solution(double step, double inv_M, double rho) {
+  return -1.0 / 8.0 * std::pow(step, 4) * std::pow(inv_M, 3) * std::pow(rho, 2);
+}  
+  
+
+// Solution -1/8 * step^4 * inv_M^3 * rho^2
+
+TEST(DetailLeapfrogError, ZeroStateIsZero) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd rho = Eigen::VectorXd::Zero(3);
+  Eigen::VectorXd inv_M = Eigen::VectorXd::Ones(3);
+  EXPECT_DOUBLE_EQ(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, 1.0),
+                   0.0);
+}
+
+TEST(DetailLeapfrogError, ZeroThetaUnitEverything) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta(1), rho(1), inv_M(1);
+  theta << 0.0;
+  rho << 2.5;
+  inv_M << 0.3;
+  double step = 0.75;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
+              solution(step, inv_M[0], rho[0]), 1e-12);
+}
+
+TEST(DetailLeapfrogError, ZeroThetaTwoDimSums) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta = Eigen::VectorXd::Zero(2);
+  Eigen::VectorXd rho = Eigen::VectorXd::Ones(2);
+  Eigen::VectorXd inv_M = Eigen::VectorXd::Ones(2);
+  // doubles with two dimensions
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, 1.0),
+              2 * solution(1.0, 1.0, 1.0), 1e-12);
+}
+
+TEST(DetailLeapfrogError, ZeroThetaNonUnitInvMass) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta(1), rho(1), inv_M(1);
+  theta << 0.0;
+  rho << 1.0;
+  inv_M << 0.25;
+  double step = 1.0;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
+	      solution(step, inv_M[0], rho[0]),
+	      1e-12);
+}
+
+// halving step size divides error by 16
+TEST(DetailLeapfrogError, ZeroThetaStepScalesAsFourthPower) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta(1), rho(1), inv_M(1);
+  theta << 0.0;
+  rho << 1.0;
+  inv_M << 1.0;
+  double step = 1.0;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
+	      solution(step, inv_M[0], rho[0]), 1e-12);
+  step = 0.5;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
+	      solution(1.0, inv_M[0], rho[0]) / 16, 1e-12);
+}
+
+TEST(DetailLeapfrogError, GeneralOneDimByHand) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta(1), rho(1), inv_M(1);
+  theta << 1.0;
+  rho << 1.0;
+  inv_M << 1.0;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, 1.0),
+              -5.0 / 32.0, 1e-12);
+}
+
+TEST(DetailLeapfrogError, ZeroMomentumByHand) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta(1), rho(1), inv_M(1);
+  theta << 1.0;
+  rho << 0.0;
+  inv_M << 1.0;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, 1.0),
+              3.0 / 32.0, 1e-12);
+}
+
+TEST(DetailLeapfrogError, TinyStepIsNearlyZero) {
+  GoodLogpGrad f;
+  Eigen::VectorXd theta(2), rho(2), inv_M(2);
+  theta << 1.0, -2.0;
+  rho << 0.5, 1.0;
+  inv_M << 1.0, 1.0;
+  double step = 1e-4;
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
+	      0.0, 1e-12);
 }


### PR DESCRIPTION
Adds `adapt_step_build(rng, logp_grad)` as alternative to simple `.build()` for `InitConfigBuilder`.  It is the same general idea as the one in NUTS/Stan, but targeting a slightly higher initial acceptance rate and using finer grained stepping.

I also updated `examples/walnuts_api` to use this with a way-too-high starting step size to make sure it's really working.