### PR TITLE
Add callback for error handling in NoExceptLogpGrad

### DIFF
--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -4,6 +4,7 @@
 #include <random>
 
 #include <walnuts.hpp>
+#include "handlers.hpp"
 
 static double total_time = 0.0;
 static std::size_t count = 0;
@@ -113,7 +114,7 @@ static void run_adaptive_walnuts(F& target_logp_grad) {
   std::cout << "Warmup configuration:\n" << warmup_cfg << std::endl;
   std::cout << "Sampling configuration:\n" << sampling_cfg << std::endl;
 
-  walnuts::ChainStore handler;
+  ChainStore handler;
   walnuts::AdaptiveWalnuts adapt(rng, handler, target_logp_grad,
                                  init_cfg.init_chain_config(0), warmup_cfg,
                                  sampling_cfg);

--- a/examples/handlers.hpp
+++ b/examples/handlers.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -13,9 +14,9 @@
 
 #include <Eigen/Dense>
 
-#include "walnuts/validate.hpp"
+#include <walnuts/validate.hpp>
 
-namespace walnuts::detail {
+namespace detail {
 
 /**
  * @brief Internal flag with value `true` if C++ received `SIGINT`.
@@ -53,9 +54,23 @@ static void write_vector(std::ostream& os, const Eigen::VectorXd& v) {
   os.write(data, size);
 }
 
-}  // namespace walnuts::detail
+/**
+ * @brief Validate that the specified stream is open.
+ *
+ * @tparam S The type of the stream.
+ * @param[in] s The stream.
+ * @param[in] name The name of the stream.
+ * @throw invalid_argument If the stream is not open.
+ */
+template <typename S>
+inline void validate_open(const S& s, const std::string& name) {
+  if (s.is_open()) {
+    return;
+  }
+  throw std::invalid_argument("could not open stream from: " + name);
+}
 
-namespace walnuts {
+}  // namespace detail
 
 /**
  * @brief An interrupt callback for C++.
@@ -157,11 +172,10 @@ class ChainStore {
     lps_.push_back(lp);
   }
 
-  /**
-   * @brief Handle an event to stop sampling.
-   */
-  void on_stop() {
-    // TODO: add stop semaphore, catch interrupts
+  void on_logp_exception(const Eigen::VectorXd& position,
+                         const std::exception& exn) const noexcept {
+    std::cout << "Logp failed with exception " << exn.what() << " at "
+              << position.transpose() << "\n";
   }
 
   /**
@@ -444,5 +458,3 @@ static void write_sample(const std::string& file_name,
   detail::validate_open(os, file_name);
   write_sample(os, handlers, include_warmup);
 }
-
-}  // namespace walnuts

--- a/examples/stan_cli.cpp
+++ b/examples/stan_cli.cpp
@@ -88,6 +88,12 @@ class StanHandler {
   void on_warmup_complete(double step_size,
                           const Eigen::VectorXd& diag_inv_mass) {}
 
+  void on_logp_exception(const Eigen::VectorXd& position,
+                         const std::exception& exn) const noexcept {
+    std::cout << "Logp failed with exception " << exn.what() << " at "
+              << position.transpose() << "\n";
+  }
+
   void summarize() {
     auto names = model_.param_names();
     ::summarize(names, draws_);

--- a/examples/walnuts_api.cpp
+++ b/examples/walnuts_api.cpp
@@ -10,8 +10,9 @@
 
 // overincludes, but it's what a client would call
 #include <walnuts.hpp>
+#include "handlers.hpp"
 
-double geom_mean_step(const std::vector<walnuts::ChainStore>& handlers) {
+double geom_mean_step(const std::vector<ChainStore>& handlers) {
   if (handlers.size() == 0) {
     return 0.0;
   }
@@ -22,8 +23,7 @@ double geom_mean_step(const std::vector<walnuts::ChainStore>& handlers) {
   return std::exp(sum / handlers.size());
 }
 
-Eigen::VectorXd geom_mean_inv_mass(
-    const std::vector<walnuts::ChainStore>& handlers) {
+Eigen::VectorXd geom_mean_inv_mass(const std::vector<ChainStore>& handlers) {
   if (handlers.size() == 0) {
     return {};
   }
@@ -52,13 +52,14 @@ int main() {
   std::size_t num_chains = 4;
   std::size_t dims = 100;
 
-  walnuts::CppInterruptCallback interrupt_callback;
-  walnuts::GlobalStore global_handler;
-  std::vector<walnuts::ChainStore> chain_handlers(num_chains);
+  CppInterruptCallback interrupt_callback;
+  GlobalStore global_handler;
+  std::vector<ChainStore> chain_handlers(num_chains);
 
-  auto init_cfg = walnuts::InitConfigBuilder(num_chains, dims)
-    .step_sizes(100.2)  // test that adapt_step works with absurd init
-    .adapt_step_build(rng, logp_grad);
+  auto init_cfg =
+      walnuts::InitConfigBuilder(num_chains, dims)
+          .step_sizes(100.2)  // test that adapt_step works with absurd init
+          .adapt_step_build(rng, logp_grad);
 
   auto warmup_cfg =
       walnuts::WarmupConfigBuilder().min_max_iter(50, 2000).build();
@@ -101,9 +102,9 @@ int main() {
   std::cout << "WRITING BINARY TO FILES: step_size.wal, mass_matrix.wal, "
                "sample.wal\n\n";
 
-  walnuts::write_step_size("step_size.wal", chain_handlers);
-  walnuts::write_mass_matrix("mass_matrix.wal", chain_handlers);
-  walnuts::write_sample("sample.wal", chain_handlers);
+  write_step_size("step_size.wal", chain_handlers);
+  write_mass_matrix("mass_matrix.wal", chain_handlers);
+  write_sample("sample.wal", chain_handlers);
 
   std::cout << "FINISHED NORMALLY." << std::endl << std::endl;
 }

--- a/include/walnuts.hpp
+++ b/include/walnuts.hpp
@@ -8,7 +8,6 @@
 #include "walnuts/api.hpp"
 #include "walnuts/concepts.hpp"
 #include "walnuts/config.hpp"
-#include "walnuts/handlers.hpp"
 #include "walnuts/online_moments.hpp"
 #include "walnuts/sampler.hpp"
 #include "walnuts/spsc_buffer.hpp"

--- a/include/walnuts/adaptive_walnuts.hpp
+++ b/include/walnuts/adaptive_walnuts.hpp
@@ -210,7 +210,7 @@ class AdaptiveWalnuts {
         sampling_cfg_(std::cref(sampling_cfg)),
         rand_(rng),
         handler_(handler),
-        logp_grad_(logp_grad),
+        logp_grad_(logp_grad, handler),
         theta_(init_chain_cfg.position()),
         iteration_(0),
         adam_(init_chain_cfg.step_size(), warmup_cfg.step_accept_rate_target(),
@@ -343,7 +343,7 @@ class AdaptiveWalnuts {
   std::reference_wrapper<H> handler_;
 
   /** The target log density/gradient function. */
-  const detail::NoExceptLogpGrad<F> logp_grad_;
+  const detail::NoExceptLogpGrad<F, H> logp_grad_;
 
   /** The current state. */
   Eigen::VectorXd theta_;

--- a/include/walnuts/concepts.hpp
+++ b/include/walnuts/concepts.hpp
@@ -99,19 +99,6 @@ concept Sampler = requires(S& s, const S& cs) {
 };
 
 /**
- * @brief Concept for a stream that reports whether it is open.
- *
- * A type `S` satisfies `OpenableStream` if `s.is_open()` is callable on
- * a const instance and returns a value convertible to `bool`. This
- * matches the interface of standard file streams (`std::ifstream`,
- * `std::ofstream`, `std::fstream`).
- */
-template <typename S>
-concept OpenableStream = requires(const S& s) {
-  { s.is_open() } -> std::convertible_to<bool>;
-};
-
-/**
  * @brief Concept for a step size adaptation handler.
  *
  * A type `H` satisfies `StepSizeAdapter` if it provides:
@@ -202,16 +189,30 @@ concept InterruptCallback = requires(H& h, const H& ch, double r_hat) {
 };
 
 /**
+ * @brief Concept for handler for errors
+ * The following member is required
+ * - `on_logp_exception(const Eigen::VectorXd&, std::exception&)` called
+ *    when the log density function throws an error
+ */
+template <typename H>
+concept ErrorCallback =
+    requires(H& h, const Eigen::VectorXd& position, const std::exception& exn) {
+      { h.on_logp_exception(position, exn) } -> std::same_as<void>;
+      { noexcept(h.on_logp_exception(position, exn)) };
+    };
+
+/**
  * @brief Concept for a handler of sampling events.
  *
- * A type `H` satisfies `SampleHandler` if it provides the following
- * member functions, each callable on a non-const instance and
- * returning `void`:
+ * A type `H` satisfies `SampleHandler` if it satisfies `ErrorCallback` and
+ * additional provides the following member functions, each callable
+ * on a non-const instance and returning `void`:
  *  - `on_sample(const Eigen::VectorXd&, double)` called once per
  *    draw with the position and log density.
  */
 template <typename H>
 concept SampleHandler =
+    ErrorCallback<H> &&
     requires(H& h, const Eigen::VectorXd& position, double lp) {
       { h.on_sample(position, lp) } -> std::same_as<void>;
     };

--- a/include/walnuts/util.hpp
+++ b/include/walnuts/util.hpp
@@ -240,17 +240,16 @@ inline double logp_momentum(const Eigen::VectorXd& rho,
  * @param[in] step The step size.
  */
 template <LogpGrad F>
-double leapfrog_error(const F& logp_grad,
-		      const Eigen::VectorXd& theta,
-		      const Eigen::VectorXd& rho,
-		      const Eigen::VectorXd& inv_M,
-		      double step) {
+double leapfrog_error(const F& logp_grad, const Eigen::VectorXd& theta,
+                      const Eigen::VectorXd& rho, const Eigen::VectorXd& inv_M,
+                      double step) {
   Eigen::VectorXd grad;
   double logp;
   logp_grad(theta, logp, grad);
   logp += detail::logp_momentum(rho, inv_M);
   Eigen::VectorXd rho_star = rho + 0.5 * step * grad;
-  Eigen::VectorXd theta_star = theta + step * (inv_M.array() * rho_star.array()).matrix();
+  Eigen::VectorXd theta_star =
+      theta + step * (inv_M.array() * rho_star.array()).matrix();
   double logp_star;
   logp_grad(theta_star, logp_star, grad);
   rho_star = rho_star + 0.5 * step * grad;
@@ -283,33 +282,33 @@ double leapfrog_error(const F& logp_grad,
  * @param D The dimensioanlity
  * @return The adapted step size.
  */
- template <std::uniform_random_bit_generator RNG, LogpGrad F>
- double adapt_step(RNG& rng, const F& logp_grad,
-		   const Eigen::VectorXd& theta,
-		   const Eigen::VectorXd& M,
-		   double step,
-		   std::size_t D) {
-   detail::Random<RNG> rand(rng);
-   Eigen::VectorXd inv_M = M.array().inverse().matrix();
-   Eigen::VectorXd rho = (rand.standard_normal(static_cast<Eigen::Index>(D))
-			  .array() * M.array().sqrt()).matrix();
-   while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step)
-	  > std::log(0.9)) {
-     step *= 2;
-   }
-   while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) < std::log(0.6)) {
-     step *= std::sqrt(0.5);
-   }
-   return step;
- }
-  
+template <std::uniform_random_bit_generator RNG, LogpGrad F>
+double adapt_step(RNG& rng, const F& logp_grad, const Eigen::VectorXd& theta,
+                  const Eigen::VectorXd& M, double step, std::size_t D) {
+  detail::Random<RNG> rand(rng);
+  Eigen::VectorXd inv_M = M.array().inverse().matrix();
+  Eigen::VectorXd rho =
+      (rand.standard_normal(static_cast<Eigen::Index>(D)).array() *
+       M.array().sqrt())
+          .matrix();
+  while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) >
+         std::log(0.9)) {
+    step *= 2;
+  }
+  while (detail::leapfrog_error(logp_grad, theta, rho, inv_M, step) <
+         std::log(0.6)) {
+    step *= std::sqrt(0.5);
+  }
+  return step;
+}
+
 /**
  * @brief A wrapper for a log density and gradient function that traps
  * exceptions.
  *
  * @tparam F Type of underlying log density and gradient function.
  */
-template <LogpGrad F>
+template <LogpGrad F, ErrorCallback H>
 class NoExceptLogpGrad {
  public:
   /**
@@ -321,8 +320,10 @@ class NoExceptLogpGrad {
    *
    * @param[in] logp_grad The base log density and gradient function, called
    * back.
+   * @param[in] handler The sample handler, used when exceptions are thrown.
    */
-  NoExceptLogpGrad(const F& logp_grad) : logp_grad_(std::cref(logp_grad)) {}
+  NoExceptLogpGrad(const F& logp_grad, H& handler)
+      : logp_grad_(std::cref(logp_grad)), handler_(handler) {}
 
   /**
    * @brief Given the specified position, set the log density and
@@ -336,9 +337,9 @@ class NoExceptLogpGrad {
                   Eigen::VectorXd& grad) const noexcept {
     try {
       logp_grad_.get()(x, logp, grad);
-    } catch (...) {
+    } catch (const std::exception& e) {
+      handler_.get().on_logp_exception(x, e);
       // logp_grad failure equivalent to -inf log density
-      // TODO: add logging for this kind of thing
       logp = -std::numeric_limits<double>::infinity();
       grad.setZero(x.size());
     }
@@ -346,6 +347,7 @@ class NoExceptLogpGrad {
 
   /** The log density and gradient function. */
   const std::reference_wrapper<const F> logp_grad_;
+  const std::reference_wrapper<H> handler_;
 };
 
 /**

--- a/include/walnuts/validate.hpp
+++ b/include/walnuts/validate.hpp
@@ -14,22 +14,6 @@
 namespace walnuts::detail {
 
 /**
- * @brief Validate that the specified stream is open.
- *
- * @tparam S The type of the stream.
- * @param[in] s The stream.
- * @param[in] name The name of the stream.
- * @throw invalid_argument If the stream is not open.
- */
-template <OpenableStream S>
-inline void validate_open(const S& s, const std::string& name) {
-  if (s.is_open()) {
-    return;
-  }
-  throw std::invalid_argument("could not open stream from: " + name);
-}
-
-/**
  * @brief Validate the standard vector is the specified size.
  *
  * @tparam T The type of vector elements.

--- a/include/walnuts/walnuts.hpp
+++ b/include/walnuts/walnuts.hpp
@@ -641,7 +641,7 @@ class WalnutsSampler {
                  double max_error)
       : rand_(rng),
         sample_handler_(sample_handler),
-        logp_grad_(logp_grad),
+        logp_grad_(logp_grad, sample_handler),
         theta_(theta),
         inv_mass_(inv_mass),
         cholesky_mass_(inv_mass.array().sqrt().inverse().matrix()),
@@ -735,7 +735,7 @@ class WalnutsSampler {
   std::reference_wrapper<H> sample_handler_;
 
   /** The target log density/gradient function. */
-  const detail::NoExceptLogpGrad<F> logp_grad_;
+  const detail::NoExceptLogpGrad<F, H> logp_grad_;
 
   /** The current position. */
   Eigen::VectorXd theta_;

--- a/tests/test_util.hpp
+++ b/tests/test_util.hpp
@@ -6,9 +6,10 @@
 #include <Eigen/Dense>
 
 struct ThrowingLogpGrad {
+  static constexpr char const* const ERRORMSG = "logp_grad failed";
   void operator()(const Eigen::VectorXd& x, double& logp,
                   Eigen::VectorXd& grad) const {
-    throw std::runtime_error("logp_grad failed");
+    throw std::runtime_error(ERRORMSG);
   }
 };
 
@@ -18,6 +19,17 @@ struct GoodLogpGrad {
     logp = -0.5 * x.squaredNorm();
     grad = -x;
   }
+};
+
+struct TattleTaleHandler {
+  void on_logp_exception(const Eigen::VectorXd position,
+                         const std::exception& e) {
+    latest_err = e.what();
+    latest_err_pos = position;
+  }
+
+  std::string latest_err;
+  Eigen::VectorXd latest_err_pos;
 };
 
 static std::vector<double> inf_nan() {
@@ -55,8 +67,8 @@ static std::vector<double> inf_nan_neg_zero_leq_one() {
 
 template <int R, int C>
 static void expect_near(const Eigen::Matrix<double, R, C>& x,
-			const Eigen::Matrix<double, R, C>& y,
-			double tolerance = 1e-10) {
+                        const Eigen::Matrix<double, R, C>& y,
+                        double tolerance = 1e-10) {
   EXPECT_EQ(x.size(), y.size());
   for (Eigen::Index n = 0; n < x.size(); ++n) {
     EXPECT_NEAR(x(n), y(n), tolerance);

--- a/tests/test_util.hpp
+++ b/tests/test_util.hpp
@@ -6,10 +6,10 @@
 #include <Eigen/Dense>
 
 struct ThrowingLogpGrad {
-  static constexpr char const* const ERRORMSG = "logp_grad failed";
+  static constexpr char const* const ERROR_MSG = "logp_grad failed";
   void operator()(const Eigen::VectorXd& x, double& logp,
                   Eigen::VectorXd& grad) const {
-    throw std::runtime_error(ERRORMSG);
+    throw std::runtime_error(ERROR_MSG);
   }
 };
 

--- a/tests/util_test.cpp
+++ b/tests/util_test.cpp
@@ -269,7 +269,8 @@ TEST(LogpMomentum, KnownValueLinearTransform) {
 
 TEST(NoExceptLogpGrad, NormalEvaluation) {
   GoodLogpGrad f;
-  walnuts::detail::NoExceptLogpGrad wrapped(f);
+  TattleTaleHandler h;
+  walnuts::detail::NoExceptLogpGrad wrapped(f, h);
   Eigen::VectorXd x(3);
   x << 1.0, 2.0, 3.0;
   double logp;
@@ -281,7 +282,8 @@ TEST(NoExceptLogpGrad, NormalEvaluation) {
 
 TEST(NoExceptLogpGrad, ExceptionSetsNegInfAndZeroGrad) {
   ThrowingLogpGrad f;
-  walnuts::detail::NoExceptLogpGrad wrapped(f);
+  TattleTaleHandler h;
+  walnuts::detail::NoExceptLogpGrad wrapped(f, h);
   Eigen::VectorXd x(3);
   x << 1.0, 2.0, 3.0;
   double logp = 0.0;
@@ -289,6 +291,7 @@ TEST(NoExceptLogpGrad, ExceptionSetsNegInfAndZeroGrad) {
   wrapped(x, logp, grad);
   EXPECT_EQ(logp, -std::numeric_limits<double>::infinity());
   expect_near(grad, Eigen::VectorXd::Zero(3).eval());
+  EXPECT_EQ(h.latest_err, ThrowingLogpGrad::ERRORMSG);
 }
 
 // grad() function **************************************************
@@ -381,8 +384,7 @@ TEST(DetailVariance, ShiftInvariantQuadraticScale) {
 
 double solution(double step, double inv_M, double rho) {
   return -1.0 / 8.0 * std::pow(step, 4) * std::pow(inv_M, 3) * std::pow(rho, 2);
-}  
-  
+}
 
 // Solution -1/8 * step^4 * inv_M^3 * rho^2
 
@@ -424,8 +426,7 @@ TEST(DetailLeapfrogError, ZeroThetaNonUnitInvMass) {
   inv_M << 0.25;
   double step = 1.0;
   EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
-	      solution(step, inv_M[0], rho[0]),
-	      1e-12);
+              solution(step, inv_M[0], rho[0]), 1e-12);
 }
 
 // halving step size divides error by 16
@@ -437,10 +438,10 @@ TEST(DetailLeapfrogError, ZeroThetaStepScalesAsFourthPower) {
   inv_M << 1.0;
   double step = 1.0;
   EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
-	      solution(step, inv_M[0], rho[0]), 1e-12);
+              solution(step, inv_M[0], rho[0]), 1e-12);
   step = 0.5;
   EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
-	      solution(1.0, inv_M[0], rho[0]) / 16, 1e-12);
+              solution(1.0, inv_M[0], rho[0]) / 16, 1e-12);
 }
 
 TEST(DetailLeapfrogError, GeneralOneDimByHand) {
@@ -470,6 +471,6 @@ TEST(DetailLeapfrogError, TinyStepIsNearlyZero) {
   rho << 0.5, 1.0;
   inv_M << 1.0, 1.0;
   double step = 1e-4;
-  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step),
-	      0.0, 1e-12);
+  EXPECT_NEAR(walnuts::detail::leapfrog_error(f, theta, rho, inv_M, step), 0.0,
+              1e-12);
 }

--- a/tests/util_test.cpp
+++ b/tests/util_test.cpp
@@ -291,7 +291,7 @@ TEST(NoExceptLogpGrad, ExceptionSetsNegInfAndZeroGrad) {
   wrapped(x, logp, grad);
   EXPECT_EQ(logp, -std::numeric_limits<double>::infinity());
   expect_near(grad, Eigen::VectorXd::Zero(3).eval());
-  EXPECT_EQ(h.latest_err, ThrowingLogpGrad::ERRORMSG);
+  EXPECT_EQ(h.latest_err, ThrowingLogpGrad::ERROR_MSG);
 }
 
 // grad() function **************************************************


### PR DESCRIPTION
This adds `void on_logp_exception(const Eigen::VectorXd& position, const std::exception& exn)` to the handler concepts, resolving a TODO for some sort of logging in `NoExceptLogpGrad`

I also moved `handlers.hpp` to `examples/` -- that's the only place it is used, and I don't think we should be providing such things in the public API