### PR TITLE
corrected doc for init_radius in pyfunc

### DIFF
--- a/python/src/walnutpie/pyfunc.py
+++ b/python/src/walnutpie/pyfunc.py
@@ -107,7 +107,7 @@ def walnuts_pyfunc(
         Numeric id for the first chain, by default 1. The remaining chains are given consecutive ids following this one.
         This controls the random number generation, along with the ``seed``.
     init_radius : float, optional
-        The bounds of uniform random initialization (``-init_radius``, ``init_radius``), positive, by default ``2.0``.
+        The standard deviation of a zero-centered normal random initialization, by default 2.0.
     init_inv_metric : Optional[np.ndarray], optional
         The diagonal of the initial diagonal inverse metric, positive entries and size equal to transformed
         (unconstrained) dimension, or ``None``, in which case the mass matrix is initialized with a smoothed.


### PR DESCRIPTION
Fixes the doc for `init_radius` to indicate it's the standard deviation of a zero-centered normal used for initialization.  I'll create an issue for changing its name to `init_std` to indicate it's a standard deviation.